### PR TITLE
Adding organisation to the speakers profile on the website

### DIFF
--- a/Public/css/style.css
+++ b/Public/css/style.css
@@ -459,12 +459,13 @@ ul.tickets li a {
 }
 
 .speaker-grid-name {
-    padding-top: 20px;
+    padding-top: 6px;
     font-weight: 600;
     font-size: 16px;
 }
 
 .speaker-grid-title {
+    padding-top: 4px;
     font-weight: 300;
     font-size: 14px;
 }

--- a/Resources/Views/Home/_speakers.leaf
+++ b/Resources/Views/Home/_speakers.leaf
@@ -33,7 +33,7 @@
                         </div>
                     </a>
                     <p class="speaker-grid-name">#(speaker.name)</p>
-                    <p class="speaker-grid-title">#(speaker.title)</p>
+                    <p class="speaker-grid-title">#(speaker.organisation)</p>
                 </div>
             </div>
         #endfor


### PR DESCRIPTION
This PR adds the organisation for each speaker to the website

<img width="261" alt="Screenshot 2022-05-27 at 17 47 36" src="https://user-images.githubusercontent.com/1519998/170743427-0600bdad-30e7-4122-b71f-4747365a8940.png">

