### PR TITLE
Hide the twitter icon if a speaker doesn't have one

### DIFF
--- a/Resources/Views/Home/_speakers.leaf
+++ b/Resources/Views/Home/_speakers.leaf
@@ -27,11 +27,13 @@
                     <img class="speaker-grid-element-image" src="https://swiftleeds-speakers.s3.eu-west-2.amazonaws.com/#(speaker.profileImage)"/>
                 </div>
                 <div class="speaker-grid-element-info">
+                    #if(speaker.twitter):
                     <a href="https://twitter.com/#(speaker.twitter)">
                         <div class="speaker-grid-social">
                             <img src="/img/twitter-vector.svg"/>
                         </div>
                     </a>
+                    #endif
                     <p class="speaker-grid-name">#(speaker.name)</p>
                     <p class="speaker-grid-title">#(speaker.organisation)</p>
                 </div>


### PR DESCRIPTION
A small tweak, just hides the twitter if they don't have one. We could look to expand this in future by allowing different socials, but this is a good start.
| Preview |
| - | 
|<img width="1381" alt="Screenshot 2022-06-14 at 22 27 54" src="https://user-images.githubusercontent.com/13989549/173692247-e61913bf-ad94-47cf-a3bc-a25580076291.png">|