### PR TITLE
Adding Markdown Support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -29,6 +29,15 @@
         }
       },
       {
+        "package": "cmark",
+        "repositoryURL": "https://github.com/brokenhandsio/cmark-gfm.git",
+        "state": {
+          "branch": null,
+          "revision": "e97450a77a40f12b4f88f95891621c3b5d8669de",
+          "version": "2.1.0"
+        }
+      },
+      {
         "package": "console-kit",
         "repositoryURL": "https://github.com/vapor/console-kit.git",
         "state": {
@@ -89,6 +98,24 @@
           "branch": null,
           "revision": "983fcbe89e7153c4d5870bdc76bf57a56817225f",
           "version": "1.4.0"
+        }
+      },
+      {
+        "package": "LeafMarkdown",
+        "repositoryURL": "https://github.com/vapor-community/leaf-markdown.git",
+        "state": {
+          "branch": null,
+          "revision": "ecec9a93102139609aa5a84c51990fc305fbc1d6",
+          "version": "3.0.1"
+        }
+      },
+      {
+        "package": "SwiftMarkdown",
+        "repositoryURL": "https://github.com/vapor-community/markdown.git",
+        "state": {
+          "branch": null,
+          "revision": "f0cdf125947c06685ebaef633fd00ae5247a1cfc",
+          "version": "0.7.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/leaf.git", from: "4.0.0"),
         .package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.0.0"),
         .package(name: "AWSSDKSwift", url: "https://github.com/swift-aws/aws-sdk-swift.git", from: "4.7.0"),
+        .package(name: "LeafMarkdown", url: "https://github.com/vapor-community/leaf-markdown.git", .upToNextMajor(from: "3.0.0")),
     ],
     targets: [
         .target(
@@ -23,6 +24,7 @@ let package = Package(
                 .product(name: "Fluent", package: "fluent"),
                 .product(name: "FluentPostgresDriver", package: "fluent-postgres-driver"),
                 .product(name: "S3", package: "AWSSDKSwift"),
+                .product(name: "LeafMarkdown", package: "LeafMarkdown")
             ],
             swiftSettings: [
                 // Enable better optimizations when building in Release configuration. Despite the use of

--- a/Resources/Views/Authentication/presentation_form.leaf
+++ b/Resources/Views/Authentication/presentation_form.leaf
@@ -51,7 +51,8 @@
                 </div>
                 <div class="mb-3">
                   <label for="synopsis" class="form-label">Presentation synopsis</label>
-                  <textarea class="form-control" name="synopsis" id="synopsis" rows="3">#(presentation.synopsis)</textarea>
+                  <textarea class="form-control" name="synopsis" id="synopsis" rows="10">#(presentation.synopsis)</textarea>
+                  <p>* Supports Markdown</p>
                 </div>
                 <div class="mb-3">
                   <label for="formFile" class="form-label">Presentation image</label>

--- a/Resources/Views/Home/_schedule.leaf
+++ b/Resources/Views/Home/_schedule.leaf
@@ -43,7 +43,7 @@
             <br />
             <br />
             <div class="col-md-4 col-lg">
-              #(presentation.synopsis)
+              #markdown((presentation.synopsis))
               <br />
               <br />
               <strong>#(presentation.speaker.name)</strong> / #(presentation.speaker.organisation)

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -3,6 +3,7 @@ import Leaf
 import Fluent
 import FluentPostgresDriver
 import Foundation
+import LeafMarkdown
 
 // configures your application
 public func configure(_ app: Application) throws {
@@ -13,6 +14,7 @@ public func configure(_ app: Application) throws {
     app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
     app.sessions.use(.fluent(.psql))
     app.leaf.tags["dateFormat"] = NowTag()
+    app.leaf.tags["markdown"] = Markdown()
 
     // Use Leaf
     app.views.use(.leaf)


### PR DESCRIPTION
We were struggling to render good blocks of speaker details and so it makes sense to support Markdown for the frontend.

<img width="785" alt="Screenshot 2022-06-27 at 12 06 37" src="https://user-images.githubusercontent.com/1519998/175927669-6e911778-afe7-4142-a69f-5471541c7d76.png">
