### PR TITLE
Sorting the DB Query Based on Start Time

### DIFF
--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -12,7 +12,7 @@ func routes(_ app: Application) throws {
     route.get { req -> View in
         do {
             let speakers = try await Speaker.query(on: req.db).with(\.$presentations).all()
-            if let presentations = try? await Presentation.query(on: req.db).with(\.$speaker).all() {
+            if let presentations = try? await Presentation.query(on: req.db).sort(\.$startDate).with(\.$speaker).all() {
                 return try await req.view.render("Home/home", HomeContext(speakers: speakers, cfpEnabled: cfpExpirationDate > Date(), presentations: presentations))
             }
             return try await req.view.render("Home/home", HomeContext(speakers: speakers, cfpEnabled: cfpExpirationDate > Date(), presentations: []))


### PR DESCRIPTION
This is increasingly important because otherwise it queries based on the last update, so if we have to make schedule changes it will change the ordering.