### PR TITLE
Schedule API

### DIFF
--- a/Sources/App/Features/Activities/Models/ActivityResponse.swift
+++ b/Sources/App/Features/Activities/Models/ActivityResponse.swift
@@ -1,0 +1,18 @@
+//
+//  ActivityResponse.swift
+//  
+//
+//  Created by Alex Logan on 25/07/2022.
+//
+
+import Foundation
+import Vapor
+
+struct ActivityResponse: Content {
+    let id: UUID?
+    let title: String
+    let subtitle: String?
+    let description: String?
+    let metadataURL: String?
+    let image: String?
+}

--- a/Sources/App/Features/Activities/Transformers/ActivityTransformer.swift
+++ b/Sources/App/Features/Activities/Transformers/ActivityTransformer.swift
@@ -16,7 +16,7 @@ enum ActivityTransformer: Transformer {
             id: entity.id,
             title: entity.title,
             subtitle: entity.subtitle,
-            description: entity.description,
+            description: entity.$description.wrappedValue ?? "", // Avoid name conflict with description
             metadataURL: entity.metadataURL,
             image: entity.image
         )

--- a/Sources/App/Features/Activities/Transformers/ActivityTransformer.swift
+++ b/Sources/App/Features/Activities/Transformers/ActivityTransformer.swift
@@ -1,0 +1,24 @@
+//
+//  ActivityTransformer.swift
+//  
+//
+//  Created by Alex Logan on 25/07/2022.
+//
+
+import Foundation
+
+enum ActivityTransformer: Transformer {
+    static func transform(_ entity: Activity?) -> ActivityResponse? {
+        guard let entity = entity else {
+             return nil
+        }
+        return .init(
+            id: entity.id,
+            title: entity.title,
+            subtitle: entity.subtitle,
+            description: entity.description,
+            metadataURL: entity.metadataURL,
+            image: entity.image
+        )
+    }
+}

--- a/Sources/App/Features/Events/Models/Event.swift
+++ b/Sources/App/Features/Events/Models/Event.swift
@@ -29,6 +29,9 @@ final class Event: Model, Content {
     
     @Children(for: \.$event)
     var presentations: [Presentation]
+
+    @Children(for: \.$event)
+    var slots: [Slot]
     
     init() { }
 }

--- a/Sources/App/Features/Presentations/Models/PresentationResponse.swift
+++ b/Sources/App/Features/Presentations/Models/PresentationResponse.swift
@@ -1,0 +1,17 @@
+//
+//  PresentationResponse.swift
+//  
+//
+//  Created by Alex Logan on 25/07/2022.
+//
+
+import Foundation
+import Vapor
+
+struct PresentationResponse: Content {
+    let id: UUID?
+    let title: String
+    let synopsis: String
+    let image: String?
+    let speaker: SpeakerResponse?
+}

--- a/Sources/App/Features/Presentations/Transformers/PresentationTransformer.swift
+++ b/Sources/App/Features/Presentations/Transformers/PresentationTransformer.swift
@@ -12,12 +12,21 @@ enum PresentationTransformer: Transformer {
         guard let entity = entity else {
             return nil
         }
+
+        let speaker: SpeakerResponse?
+
+        if let speakerEntity = entity.$speaker.value {
+            speaker = SpeakerTransformer.transform(speakerEntity)
+        } else {
+            speaker = nil
+        }
+
         return PresentationResponse(
             id: entity.id,
             title: entity.title,
             synopsis: entity.synopsis,
             image: entity.image,
-            speaker: SpeakerTransformer.transform(entity.speaker)
+            speaker: speaker
         )
     }
 }

--- a/Sources/App/Features/Presentations/Transformers/PresentationTransformer.swift
+++ b/Sources/App/Features/Presentations/Transformers/PresentationTransformer.swift
@@ -1,0 +1,23 @@
+//
+//  PresentationTransformer.swift
+//  
+//
+//  Created by Alex Logan on 25/07/2022.
+//
+
+import Foundation
+
+enum PresentationTransformer: Transformer {
+    static func transform(_ entity: Presentation?) -> PresentationResponse? {
+        guard let entity = entity else {
+            return nil
+        }
+        return PresentationResponse(
+            id: entity.id,
+            title: entity.title,
+            synopsis: entity.synopsis,
+            image: entity.image,
+            speaker: SpeakerTransformer.transform(entity.speaker)
+        )
+    }
+}

--- a/Sources/App/Features/Schedule/ScheduleAPIController.swift
+++ b/Sources/App/Features/Schedule/ScheduleAPIController.swift
@@ -1,0 +1,38 @@
+//
+//  ScheduleAPIController.swift
+//  
+//
+//  Created by Alex Logan on 25/07/2022.
+//
+
+import Vapor
+import Fluent
+
+
+struct ScheduleAPIController: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get("", use: onGet)
+    }
+
+    private func onGet(request: Request) async throws -> Response {
+        // Get the current event
+        // In future this will need to be smarter
+        let eventWithSlots = try await Event.query(on: request.db)
+            .sort(\.$date, .ascending)
+            .with(\.$slots, { slots in
+                slots
+                    .with(\.$activity)
+                    .with(\.$presentation, { presentation in
+                        presentation.with(\.$speaker)
+                    })
+
+            })
+            .first()
+
+        var data = (eventWithSlots?.slots.compactMap(SlotTransformer.transform) ?? [])
+        data.sort(using: KeyPathComparator(\.startTime, order: .forward))
+        return try await GenericResponse(
+            data: data
+        ).encodeResponse(for: request)
+    }
+}

--- a/Sources/App/Features/Slots/Models/SlotResponse.swift
+++ b/Sources/App/Features/Slots/Models/SlotResponse.swift
@@ -1,0 +1,17 @@
+//
+//  SlotResponse.swift
+//  
+//
+//  Created by Alex Logan on 25/07/2022.
+//
+
+import Foundation
+import Vapor
+
+struct SlotResponse: Content {
+    let id: UUID?
+    let startTime: Date?
+    let duration: Double
+    let presentation: PresentationResponse?
+    let activity: ActivityResponse?
+}

--- a/Sources/App/Features/Slots/Transformers/SlotTransformer.swift
+++ b/Sources/App/Features/Slots/Transformers/SlotTransformer.swift
@@ -1,0 +1,31 @@
+//
+//  SlotTransformer.swift
+//  
+//
+//  Created by Alex Logan on 25/07/2022.
+//
+
+import Foundation
+
+enum SlotTransformer: Transformer {
+    static func transform(_ entity: Slot?) -> SlotResponse? {
+        guard let slot = entity else {
+            return nil
+        }
+        return .init(
+            id: slot.id,
+            startTime: slotDateFormatter.date(from: slot.startDate),
+            duration: slot.duration,
+            presentation: PresentationTransformer.transform(slot.presentation),
+            activity: ActivityTransformer.transform(slot.activity)
+        )
+    }
+}
+
+private extension SlotTransformer {
+    private static var slotDateFormatter: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return formatter
+    }
+}

--- a/Sources/App/Features/Slots/Transformers/SlotTransformer.swift
+++ b/Sources/App/Features/Slots/Transformers/SlotTransformer.swift
@@ -12,12 +12,28 @@ enum SlotTransformer: Transformer {
         guard let slot = entity else {
             return nil
         }
+
+        let presentation: PresentationResponse?
+        let activity: ActivityResponse?
+
+        if let presentationEntity = slot.$presentation.value {
+            presentation = PresentationTransformer.transform(presentationEntity)
+        } else {
+            presentation = nil
+        }
+
+        if let activityEntity = slot.$activity.value {
+            activity = ActivityTransformer.transform(activityEntity)
+        } else {
+            activity = nil
+        }
+
         return .init(
             id: slot.id,
             startTime: slotDateFormatter.date(from: slot.startDate),
             duration: slot.duration,
-            presentation: PresentationTransformer.transform(slot.presentation),
-            activity: ActivityTransformer.transform(slot.activity)
+            presentation: presentation,
+            activity: activity
         )
     }
 }

--- a/Sources/App/Features/Speakers/Models/SpeakerResponse.swift
+++ b/Sources/App/Features/Speakers/Models/SpeakerResponse.swift
@@ -1,0 +1,19 @@
+//
+//  SpeakerResponse.swift
+//  
+//
+//  Created by Alex Logan on 25/07/2022.
+//
+
+import Foundation
+import Vapor
+
+struct SpeakerResponse: Content {
+    let id: UUID?
+    let name: String
+    let biography: String
+    let profileImage: String
+    let twitter: String?
+    let organisation: String
+    let presentations: [PresentationResponse]?
+}

--- a/Sources/App/Features/Speakers/Transformers/SpeakerTransformer.swift
+++ b/Sources/App/Features/Speakers/Transformers/SpeakerTransformer.swift
@@ -1,0 +1,25 @@
+//
+//  SpeakerTransformer.swift
+//  
+//
+//  Created by Alex Logan on 25/07/2022.
+//
+
+import Foundation
+
+enum SpeakerTransformer: Transformer {
+    static func transform(_ entity: Speaker?) -> SpeakerResponse? {
+        guard let entity = entity else {
+            return nil
+        }
+        return .init(
+            id: entity.id,
+            name: entity.name,
+            biography: entity.biography,
+            profileImage: entity.profileImage,
+            twitter: entity.twitter,
+            organisation: entity.organisation,
+            presentations: entity.presentations.compactMap(PresentationTransformer.transform)
+        )
+    }
+}

--- a/Sources/App/Features/Speakers/Transformers/SpeakerTransformer.swift
+++ b/Sources/App/Features/Speakers/Transformers/SpeakerTransformer.swift
@@ -12,6 +12,15 @@ enum SpeakerTransformer: Transformer {
         guard let entity = entity else {
             return nil
         }
+
+        let presentations: [PresentationResponse]
+
+        if let presentationEntities = entity.$presentations.value {
+            presentations = presentationEntities.compactMap(PresentationTransformer.transform(_:))
+        } else {
+            presentations = []
+        }
+
         return .init(
             id: entity.id,
             name: entity.name,
@@ -19,7 +28,7 @@ enum SpeakerTransformer: Transformer {
             profileImage: entity.profileImage,
             twitter: entity.twitter,
             organisation: entity.organisation,
-            presentations: entity.presentations.compactMap(PresentationTransformer.transform)
+            presentations: presentations
         )
     }
 }

--- a/Sources/App/Features/Utilities/GenericResponse.swift
+++ b/Sources/App/Features/Utilities/GenericResponse.swift
@@ -1,0 +1,13 @@
+//
+//  GenericResponse.swift
+//  
+//
+//  Created by Alex Logan on 25/07/2022.
+//
+
+import Foundation
+import Vapor
+
+struct GenericResponse<Response: Content>: Content {
+    let data: Response
+}

--- a/Sources/App/Features/Utilities/Transformer.swift
+++ b/Sources/App/Features/Utilities/Transformer.swift
@@ -1,0 +1,17 @@
+//
+//  Transformer.swift
+//  
+//
+//  Created by Alex Logan on 25/07/2022.
+//
+
+import Foundation
+import Vapor
+import Fluent
+
+protocol Transformer {
+    associatedtype Entity: Model
+    associatedtype Response: Content
+
+    static func transform(_ entity: Entity?) -> Response?
+}

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -70,6 +70,7 @@ func routes(_ app: Application) throws {
     try apiRoutes.grouped("slots").register(collection: SlotAPIController())
     try apiRoutes.grouped("activities").register(collection: ActivityAPIController())
     try apiRoutes.grouped("sponsors").register(collection: SponsorAPIController())
+    try apiRoutes.grouped("schedule").register(collection: ScheduleAPIController())
 
     // MARK: - Admin Routes
     


### PR DESCRIPTION
Adds the first endpoint, including a system for transforming data and returning it to the clients.

Basic concept is just to map content rather than returning raw stuff from the database. The only transformer I didn't build was sponsors as I think someone else is about to do that 🚀 

As this is not directly requesting slots, it lives inside its own /schedule endpoint.

### Sample Response

```json
{
    "data": [
        {
            "startTime": "2000-01-01T08:00:00Z",
            "id": "D41101AB-445E-483A-B7F0-552E8CB3537E",
            "activity": {
                "image": "-6A73A5E2-3B09-4665-88F0-5F4522377F8F",
                "id": "DB5DA71B-F0DD-4040-BD2A-323FB06556FF",
                "title": "snacks",
                "subtitle": "snaaaaaaaacks",
                "description": "snaaaaaaaak",
                "metadataURL": ""
            },
            "duration": 30
        },
        {
            "startTime": "2000-01-01T09:40:00Z",
            "id": "448A53B8-F199-42EF-8ABF-0CDF74A47427",
            "presentation": {
                "speaker": {
                    "profileImage": "51990106672_e02de648a6_h.jpg-7C3078E0-0D50-4D1F-9C13-1E9AC6FD41FE",
                    "twitter": "adam9rush",
                    "id": "D33557CC-6489-4D05-AEA3-FCD34D352EEF",
                    "presentations": [],
                    "biography": "he did the conf",
                    "organisation": "yesm8",
                    "name": "Adam"
                },
                "id": "3B40984F-0676-426A-907B-6DD1FDE29902",
                "title": "gfdas",
                "synopsis": "RBGEFDSA"
            },
            "duration": 100
        }
    ]
}
```