### PR TITLE
Feature/sponsors endpoint

### DIFF
--- a/Sources/App/Features/Sponsors/Controllers/SponsorAPIController.swift
+++ b/Sources/App/Features/Sponsors/Controllers/SponsorAPIController.swift
@@ -36,16 +36,16 @@ struct SponsorAPIController: RouteCollection {
         }
         
         let fileName = "\(UUID.generateRandom().uuidString)-\(image.sponsorImage.filename)"
-//
-//        do {
-//            try await ImageService.uploadFile(
-//                data: Data(image.sponsorImage.data.readableBytesView),
-//                filename: fileName
-//            )
-//        } catch {
-//            return request.redirect(to: "/admin")
-//        }
-//
+
+        do {
+            try await ImageService.uploadFile(
+                data: Data(image.sponsorImage.data.readableBytesView),
+                filename: fileName
+            )
+        } catch {
+            return request.redirect(to: "/admin")
+        }
+
         guard let sponsorLevel = Sponsor.SponsorLevel(rawValue: input.sponsorLevel) else {
             return request.redirect(to: "/admin")
         }

--- a/Sources/App/Features/Sponsors/Controllers/SponsorAPIController.swift
+++ b/Sources/App/Features/Sponsors/Controllers/SponsorAPIController.swift
@@ -19,6 +19,7 @@ struct SponsorAPIController: RouteCollection {
     }
     
     func boot(routes: RoutesBuilder) throws {
+        routes.get("", use: onGet)
         routes.post("", use: onPost)
         routes.post(":id", use: onEdit)
     }
@@ -35,16 +36,16 @@ struct SponsorAPIController: RouteCollection {
         }
         
         let fileName = "\(UUID.generateRandom().uuidString)-\(image.sponsorImage.filename)"
-        
-        do {
-            try await ImageService.uploadFile(
-                data: Data(image.sponsorImage.data.readableBytesView),
-                filename: fileName
-            )
-        } catch {
-            return request.redirect(to: "/admin")
-        }
-        
+//
+//        do {
+//            try await ImageService.uploadFile(
+//                data: Data(image.sponsorImage.data.readableBytesView),
+//                filename: fileName
+//            )
+//        } catch {
+//            return request.redirect(to: "/admin")
+//        }
+//
         guard let sponsorLevel = Sponsor.SponsorLevel(rawValue: input.sponsorLevel) else {
             return request.redirect(to: "/admin")
         }
@@ -112,5 +113,12 @@ struct SponsorAPIController: RouteCollection {
         try await sponsor.update(on: request.db)
         
         return request.redirect(to: "/admin?page=sponsors")
+    }
+
+    private func onGet(request: Request) async throws -> Response {
+        let allSponsors = try await Sponsor.query(on: request.db).all()
+        return try await GenericResponse(
+            data: allSponsors.compactMap(SponsorTransformer.transform(_:))
+        ).encodeResponse(for: request)
     }
 }

--- a/Sources/App/Features/Sponsors/Models/SponsorResponse.swift
+++ b/Sources/App/Features/Sponsors/Models/SponsorResponse.swift
@@ -1,0 +1,21 @@
+//
+//  SponsorResponse.swift
+//  
+//
+//  Created by Alex Logan on 01/08/2022.
+//
+
+import Foundation
+import Vapor
+
+struct SponsorResponse: Content {
+    let id: UUID?
+    let name: String
+    let image: String?
+    let url: String?
+    let sponsorLevel: SponsorLevelResponse?
+}
+
+enum SponsorLevelResponse: String, Content, RawRepresentable {
+    case silver, gold, platinum
+}

--- a/Sources/App/Features/Sponsors/Transformers/SponsorTransformer.swift
+++ b/Sources/App/Features/Sponsors/Transformers/SponsorTransformer.swift
@@ -1,0 +1,21 @@
+//
+//  SponsorTransformer.swift
+//  
+//
+//  Created by Alex Logan on 01/08/2022.
+//
+
+import Foundation
+
+enum SponsorTransformer: Transformer {
+    static func transform(_ entity: Sponsor?) -> SponsorResponse? {
+        guard let entity = entity else { return nil }
+        return .init(
+            id: entity.id,
+            name: entity.name,
+            image: "https://swiftleeds-speakers.s3.eu-west-2.amazonaws.com/\(entity.image)", // Hard coded in absence of environment variables
+            url: entity.url,
+            sponsorLevel: .init(rawValue: entity.sponsorLevel.rawValue)
+        )
+    }
+}


### PR DESCRIPTION
Adds sponsor endpoint

Simple sponsor endpoint for the client to comsume.

Sanitsies URLs as the client should have no knowledge of these bucket names, it should just be provided direct URLS.

These aren't real URLS, I commented out the S3 code and just stored the generated identifier instead. Tested on a real bucket and works ok!


Sample repsonse:
```
{
    "data": [
        {
            "sponsorLevel": "silver",
            "id": "C6FFAF08-02F7-487E-B58F-76B69FD332B3",
            "name": "NAME",
            "image": "https://swiftleeds-speakers.s3.eu-west-2.amazonaws.com/E64B531D-70C5-456C-95E3-A39D69E902C3-",
            "url": "google.co.uk"
        },
        {
            "sponsorLevel": "gold",
            "id": "286CD07C-2FA8-404A-BD71-BEE626EB1618",
            "name": "GOLD",
            "image": "https://swiftleeds-speakers.s3.eu-west-2.amazonaws.com/31725AE7-6E21-41C5-BA79-2E2717375BE4-",
            "url": "twitter.com"
        },
        {
            "sponsorLevel": "platinum",
            "id": "30FD450A-719B-4F74-95B2-4816720B9719",
            "name": "ACTUALLY PLATINUM",
            "image": "https://swiftleeds-speakers.s3.eu-west-2.amazonaws.com/2F70E289-D30A-45FA-8835-3533D6CFEE7C-",
            "url": ""
        }
    ]
}
````