### PR TITLE
Return the event with the schedule

### DIFF
--- a/Sources/App/Features/Activities/Models/ActivityResponse.swift
+++ b/Sources/App/Features/Activities/Models/ActivityResponse.swift
@@ -9,7 +9,7 @@ import Foundation
 import Vapor
 
 struct ActivityResponse: Content {
-    let id: UUID?
+    let id: UUID
     let title: String
     let subtitle: String?
     let description: String?

--- a/Sources/App/Features/Activities/Transformers/ActivityTransformer.swift
+++ b/Sources/App/Features/Activities/Transformers/ActivityTransformer.swift
@@ -9,11 +9,9 @@ import Foundation
 
 enum ActivityTransformer: Transformer {
     static func transform(_ entity: Activity?) -> ActivityResponse? {
-        guard let entity = entity else {
-             return nil
-        }
+        guard let entity = entity, let id = entity.id else { return nil }
         return .init(
-            id: entity.id,
+            id: id,
             title: entity.title,
             subtitle: entity.subtitle,
             description: entity.$description.wrappedValue ?? "", // Avoid name conflict with description

--- a/Sources/App/Features/Events/Models/EventResponse.swift
+++ b/Sources/App/Features/Events/Models/EventResponse.swift
@@ -9,7 +9,7 @@ import Foundation
 import Vapor
 
 struct EventResponse: Content {
-    var id: UUID?
+    var id: UUID
     var name: String
     var date: String
     var location: String

--- a/Sources/App/Features/Events/Models/EventResponse.swift
+++ b/Sources/App/Features/Events/Models/EventResponse.swift
@@ -1,0 +1,16 @@
+//
+//  EventResponse.swift
+//  
+//
+//  Created by Alex Logan on 02/08/2022.
+//
+
+import Foundation
+import Vapor
+
+struct EventResponse: Content {
+    var id: UUID?
+    var name: String
+    var date: String
+    var location: String
+}

--- a/Sources/App/Features/Events/Transformer/EventTransformer.swift
+++ b/Sources/App/Features/Events/Transformer/EventTransformer.swift
@@ -1,0 +1,28 @@
+//
+//  EventTransformer.swift
+//  
+//
+//  Created by Alex Logan on 02/08/2022.
+//
+
+import Foundation
+
+enum EventTransformer: Transformer {
+    static func transform(_ entity: Event?) -> EventResponse? {
+        guard let entity = entity else { return nil }
+        return .init(
+            id: entity.id,
+            name: entity.name,
+            date: dateFormatter.string(from: entity.date),
+            location: entity.location
+        )
+    }
+}
+
+private extension EventTransformer {
+    static var dateFormatter: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "dd-MM-yyyy"
+        return formatter
+    }
+}

--- a/Sources/App/Features/Events/Transformer/EventTransformer.swift
+++ b/Sources/App/Features/Events/Transformer/EventTransformer.swift
@@ -9,9 +9,9 @@ import Foundation
 
 enum EventTransformer: Transformer {
     static func transform(_ entity: Event?) -> EventResponse? {
-        guard let entity = entity else { return nil }
+        guard let entity = entity, let id = entity.id else { return nil }
         return .init(
-            id: entity.id,
+            id: id,
             name: entity.name,
             date: dateFormatter.string(from: entity.date),
             location: entity.location

--- a/Sources/App/Features/Presentations/Models/PresentationResponse.swift
+++ b/Sources/App/Features/Presentations/Models/PresentationResponse.swift
@@ -9,7 +9,7 @@ import Foundation
 import Vapor
 
 struct PresentationResponse: Content {
-    let id: UUID?
+    let id: UUID
     let title: String
     let synopsis: String
     let image: String?

--- a/Sources/App/Features/Presentations/Transformers/PresentationTransformer.swift
+++ b/Sources/App/Features/Presentations/Transformers/PresentationTransformer.swift
@@ -9,9 +9,7 @@ import Foundation
 
 enum PresentationTransformer: Transformer {
     static func transform(_ entity: Presentation?) -> PresentationResponse? {
-        guard let entity = entity else {
-            return nil
-        }
+        guard let entity = entity, let id = entity.id else { return nil }
 
         let speaker: SpeakerResponse?
 
@@ -22,7 +20,7 @@ enum PresentationTransformer: Transformer {
         }
 
         return PresentationResponse(
-            id: entity.id,
+            id: id,
             title: entity.title,
             synopsis: entity.synopsis,
             image: entity.image,

--- a/Sources/App/Features/Schedule/Models/ScheduleResponse.swift
+++ b/Sources/App/Features/Schedule/Models/ScheduleResponse.swift
@@ -1,0 +1,14 @@
+//
+//  ScheduleResponse.swift
+//  
+//
+//  Created by Alex Logan on 02/08/2022.
+//
+
+import Foundation
+import Vapor
+
+struct ScheduleResponse: Content {
+    let event: EventResponse
+    let slots: [SlotResponse]
+}

--- a/Sources/App/Features/Schedule/ScheduleAPIController.swift
+++ b/Sources/App/Features/Schedule/ScheduleAPIController.swift
@@ -29,14 +29,25 @@ struct ScheduleAPIController: RouteCollection {
             })
             .first()
 
-        let data = (eventWithSlots?.slots.compactMap(SlotTransformer.transform) ?? [])
+        guard let event = eventWithSlots else {
+            throw ScheduleAPIError.notFound
+        }
+
+        guard let schedule = ScheduleTransformer.transform(event: event, slots: event.slots) else {
+            throw ScheduleAPIError.transformFailure
+        }
 
         let response = GenericResponse(
-            data: data.sorted(by: {
-                $0.startTime ?? "" < $1.startTime ?? ""
-            })
+            data: schedule
         )
         
         return try await response.encodeResponse(for: request)
+    }
+}
+
+private extension ScheduleAPIController {
+    enum ScheduleAPIError: Error {
+        case notFound
+        case transformFailure
     }
 }

--- a/Sources/App/Features/Schedule/ScheduleAPIController.swift
+++ b/Sources/App/Features/Schedule/ScheduleAPIController.swift
@@ -30,10 +30,13 @@ struct ScheduleAPIController: RouteCollection {
             .first()
 
         let data = (eventWithSlots?.slots.compactMap(SlotTransformer.transform) ?? [])
-        return try await GenericResponse(
+
+        let response = GenericResponse(
             data: data.sorted(by: {
-                $0.startTime ?? Date() < $1.startTime ?? Date()
+                $0.startTime ?? "" < $1.startTime ?? ""
             })
-        ).encodeResponse(for: request)
+        )
+        
+        return try await response.encodeResponse(for: request)
     }
 }

--- a/Sources/App/Features/Schedule/Transformer/ScheduleTransformer.swift
+++ b/Sources/App/Features/Schedule/Transformer/ScheduleTransformer.swift
@@ -1,0 +1,22 @@
+//
+//  ScheduleTransformer.swift
+//  
+//
+//  Created by Alex Logan on 02/08/2022.
+//
+
+import Foundation
+
+// A unique transformer as it doesn't actually represent an entity
+enum ScheduleTransformer {
+    static func transform(event: Event, slots: [Slot]) -> ScheduleResponse? {
+        guard let eventResponse = EventTransformer.transform(event) else { return nil }
+        return ScheduleResponse(
+            event: eventResponse,
+            slots: slots.compactMap(SlotTransformer.transform(_:)).sorted(by: {
+                $0.startTime < $1.startTime
+            })
+        )
+    }
+
+}

--- a/Sources/App/Features/Slots/Models/SlotResponse.swift
+++ b/Sources/App/Features/Slots/Models/SlotResponse.swift
@@ -10,7 +10,7 @@ import Vapor
 
 struct SlotResponse: Content {
     let id: UUID?
-    let startTime: String?
+    let startTime: String
     let duration: Double
     let presentation: PresentationResponse?
     let activity: ActivityResponse?

--- a/Sources/App/Features/Slots/Models/SlotResponse.swift
+++ b/Sources/App/Features/Slots/Models/SlotResponse.swift
@@ -10,7 +10,7 @@ import Vapor
 
 struct SlotResponse: Content {
     let id: UUID?
-    let startTime: Date?
+    let startTime: String?
     let duration: Double
     let presentation: PresentationResponse?
     let activity: ActivityResponse?

--- a/Sources/App/Features/Slots/Models/SlotResponse.swift
+++ b/Sources/App/Features/Slots/Models/SlotResponse.swift
@@ -9,7 +9,7 @@ import Foundation
 import Vapor
 
 struct SlotResponse: Content {
-    let id: UUID?
+    let id: UUID
     let startTime: String
     let duration: Double
     let presentation: PresentationResponse?

--- a/Sources/App/Features/Slots/Transformers/SlotTransformer.swift
+++ b/Sources/App/Features/Slots/Transformers/SlotTransformer.swift
@@ -9,29 +9,27 @@ import Foundation
 
 enum SlotTransformer: Transformer {
     static func transform(_ entity: Slot?) -> SlotResponse? {
-        guard let slot = entity else {
-            return nil
-        }
+        guard let entity = entity, let id = entity.id else { return nil }
 
         let presentation: PresentationResponse?
         let activity: ActivityResponse?
 
-        if let presentationEntity = slot.$presentation.value {
+        if let presentationEntity = entity.$presentation.value {
             presentation = PresentationTransformer.transform(presentationEntity)
         } else {
             presentation = nil
         }
 
-        if let activityEntity = slot.$activity.value {
+        if let activityEntity = entity.$activity.value {
             activity = ActivityTransformer.transform(activityEntity)
         } else {
             activity = nil
         }
 
         return .init(
-            id: slot.id,
-            startTime: slot.startDate,
-            duration: slot.duration,
+            id: id,
+            startTime: entity.startDate,
+            duration: entity.duration,
             presentation: presentation,
             activity: activity
         )

--- a/Sources/App/Features/Slots/Transformers/SlotTransformer.swift
+++ b/Sources/App/Features/Slots/Transformers/SlotTransformer.swift
@@ -30,18 +30,10 @@ enum SlotTransformer: Transformer {
 
         return .init(
             id: slot.id,
-            startTime: slotDateFormatter.date(from: slot.startDate),
+            startTime: slot.startDate,
             duration: slot.duration,
             presentation: presentation,
             activity: activity
         )
-    }
-}
-
-private extension SlotTransformer {
-    private static var slotDateFormatter: DateFormatter {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm"
-        return formatter
     }
 }


### PR DESCRIPTION
We pulled the timestamps out, turned them into dates, then they got encoded again. This way, we just trust the string we get out.

I merged in the work for events as its another fix for this same endpoint, and it makes sense to just have one client side change for this instead of trying to do two separate refactors for the same thing.

```
{
    "data": {
        "event": {
            "id": "4F00C6AF-93D0-4E31-BA8F-7ECD5CC0BBDB",
            "name": "Ayyy",
            "location": "Ayyyy",
            "date": "30-08-2022"
        },
        "slots": [
            {
                "startTime": "09:00",
                "id": "AC4D4B63-50C2-4D42-BEB4-D7299F9C199B",
                "presentation": {
                    "speaker": {
                        "profileImage": "-8750EE04-19C0-4475-AC84-2FB9611D1383",
                        "twitter": "a",
                        "id": "4B8A4CCB-3B2F-4049-935E-47A243ECA513",
                        "presentations": [],
                        "biography": "a",
                        "organisation": "a",
                        "name": "a"
                    },
                    "id": "A8A3818D-3A7B-4EF9-9156-34EE40D3E35B",
                    "title": "A",
                    "synopsis": "A"
                },
                "duration": 90
            }
        ]
    }
}
```