### PR TITLE
Refactor image uploads on activites to match Sponsors

### DIFF
--- a/Resources/Views/Authentication/activity_form.leaf
+++ b/Resources/Views/Authentication/activity_form.leaf
@@ -47,6 +47,11 @@
                   <div class="mb-3">
                     <label for="formFile" class="form-label">Activity picture</label>
                     <input class="form-control" type="file" id="image" name="activityImage">
+                  #if(activity.image):
+                  </br>
+                  <p class="form-label">Existing activity image</p>
+                  <img src="https://swiftleeds-speakers.s3.eu-west-2.amazonaws.com/#(activity.image)" class="img-thumbnail sponsor-thumbnail-img">
+                  #endif
                   </div>
                 <button type="submit" class="btn btn-primary">Submit</button>
             </form>


### PR DESCRIPTION
The sponsor code shows a nice preview, and handles when you edit without adding a new image. I've cloned that approach ( thanks for the code @adamoxley! I just copied it over 😄 ).

| Example |
| - | 
|<img width="1037" alt="Screenshot 2022-08-02 at 00 32 14" src="https://user-images.githubusercontent.com/13989549/182262314-a62e59b5-fcad-4be8-b5f7-e186709c88bc.png">| 

