### PR TITLE
Transform image URLS

### DIFF
--- a/Sources/App/Features/Activities/Transformers/ActivityTransformer.swift
+++ b/Sources/App/Features/Activities/Transformers/ActivityTransformer.swift
@@ -10,13 +10,20 @@ import Foundation
 enum ActivityTransformer: Transformer {
     static func transform(_ entity: Activity?) -> ActivityResponse? {
         guard let entity = entity, let id = entity.id else { return nil }
+
+        var entityImage: String? = entity.image
+
+        if let image = entityImage {
+            entityImage = ImageTransformer.transform(imageURL: image)
+        }
+
         return .init(
             id: id,
             title: entity.title,
             subtitle: entity.subtitle,
-            description: entity.$description.wrappedValue ?? "", // Avoid name conflict with description
+            description: entity.$description.wrappedValue ?? "",
             metadataURL: entity.metadataURL,
-            image: entity.image
+            image: entityImage
         )
     }
 }

--- a/Sources/App/Features/Speakers/Transformers/SpeakerTransformer.swift
+++ b/Sources/App/Features/Speakers/Transformers/SpeakerTransformer.swift
@@ -25,7 +25,7 @@ enum SpeakerTransformer: Transformer {
             id: entity.id,
             name: entity.name,
             biography: entity.biography,
-            profileImage: entity.profileImage,
+            profileImage: ImageTransformer.transform(imageURL: entity.profileImage),
             twitter: entity.twitter,
             organisation: entity.organisation,
             presentations: presentations

--- a/Sources/App/Features/Utilities/ImageTransformer.swift
+++ b/Sources/App/Features/Utilities/ImageTransformer.swift
@@ -1,0 +1,23 @@
+//
+//  ImageTransformer.swift
+//  
+//
+//  Created by Alex Logan on 05/08/2022.
+//
+
+import Foundation
+import Vapor
+
+enum ImageTransformer {
+    static func transform(imageURL: String) -> String {
+        guard !imageURL.contains(bucketName) else {
+            return imageURL
+        }
+        // Hard code region for now
+        return "https://\(bucketName).s3.eu-west-2.amazonaws.com/\(imageURL)"
+    }
+}
+
+extension ImageTransformer {
+    static let bucketName: String = Environment.get("S3_BUCKET_NAME")!
+}


### PR DESCRIPTION
The client had to hard code a URL for the storage buckets which is less than ideal. This change makes sure that images all go through a transformer which adds the bucket to it.