### PR TITLE
Add local endpoint & entities

### DIFF
--- a/Sources/App/Features/Activities/Controllers/ActivityAPIController.swift
+++ b/Sources/App/Features/Activities/Controllers/ActivityAPIController.swift
@@ -29,7 +29,7 @@ struct ActivityAPIController: RouteCollection {
         }
 
         // Image upload
-        var fileName = "\(UUID.generateRandom().uuidString)-\(image.activityImage.filename)"
+        let fileName = "\(UUID.generateRandom().uuidString)-\(image.activityImage.filename)"
 
         if !image.activityImage.filename.isEmpty {
 

--- a/Sources/App/Features/Local/LocalAPIController.swift
+++ b/Sources/App/Features/Local/LocalAPIController.swift
@@ -1,0 +1,32 @@
+//
+//  LocalAPIController.swift
+//
+//
+//  Created by Alex Logan on 25/07/2022.
+//
+
+import Vapor
+import Fluent
+
+struct LocalAPIController: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get("", use: onGet)
+    }
+
+    private func onGet(request: Request) async throws -> Response {
+        let categories = try await LocationCategory.query(on: request.db)
+            .with(\.$locations)
+            .all()
+        let response = GenericResponse(
+            data: categories.compactMap(LocationCategoryTransformer.transform(_:))
+        )
+        return try await response.encodeResponse(for: request)
+    }
+}
+
+private extension ScheduleAPIController {
+    enum ScheduleAPIError: Error {
+        case notFound
+        case transformFailure
+    }
+}

--- a/Sources/App/Features/Location Categories/Migrations/LocationCategory+Migration+V1.swift
+++ b/Sources/App/Features/Location Categories/Migrations/LocationCategory+Migration+V1.swift
@@ -1,0 +1,18 @@
+import Foundation
+import Fluent
+import Vapor
+
+class LocationCategoryMigrationV1: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema(Schema.locationCategory)
+             .id()
+             .field("name", .string, .required)
+             .field("symbol_name", .string, .required)
+             .create()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema(Schema.locationCategory).delete()
+    }
+
+}

--- a/Sources/App/Features/Location Categories/Model/LocationCategory.swift
+++ b/Sources/App/Features/Location Categories/Model/LocationCategory.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Fluent
+import Vapor
+
+final class LocationCategory: Codable, Model, Content {
+
+    static let schema = Schema.locationCategory
+
+    typealias IDValue = UUID
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Field(key: "name")
+    var name: String
+
+    @Field(key: "symbol_name")
+    var symbolName: String
+
+    @Children(for: \.$category)
+    var locations: [Location]
+
+    init() { }
+}

--- a/Sources/App/Features/Location Categories/Model/LocationCategoryResponse.swift
+++ b/Sources/App/Features/Location Categories/Model/LocationCategoryResponse.swift
@@ -1,0 +1,9 @@
+import Foundation
+import Vapor
+
+struct LocationCategoryResponse: Codable, Content {
+    var id: UUID
+    var name: String
+    var symbolName: String
+    var locations: [LocationResponse]
+}

--- a/Sources/App/Features/Location Categories/Transformers/LocationCategoryTransformer.swift
+++ b/Sources/App/Features/Location Categories/Transformers/LocationCategoryTransformer.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Vapor
+
+enum LocationCategoryTransformer: Transformer {
+    static func transform(_ entity: LocationCategory?) -> LocationCategoryResponse? {
+        guard let entity = entity, let id = entity.id else {
+            return nil
+        }
+
+        return LocationCategoryResponse(
+            id: id,
+            name: entity.name,
+            symbolName: entity.symbolName,
+            locations: entity.locations.compactMap(LocationTransformer.transform(_:))
+        )
+    }
+}

--- a/Sources/App/Features/Locations/Migrations/Location+Migration+V1.swift
+++ b/Sources/App/Features/Locations/Migrations/Location+Migration+V1.swift
@@ -9,7 +9,7 @@ class LocationMigrationV1: AsyncMigration {
              .field("name", .string, .required)
              .field("url", .string, .required)
              .field("lat", .double, .required)
-             .field("long", .double, .required)
+             .field("lon", .double, .required)
              .field("category_id", .uuid, .references(
                 Schema.locationCategory, "id", onDelete: .setNull, onUpdate: .cascade
              ))

--- a/Sources/App/Features/Locations/Migrations/Location+Migration+V1.swift
+++ b/Sources/App/Features/Locations/Migrations/Location+Migration+V1.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Fluent
+import Vapor
+
+class LocationMigrationV1: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema(Schema.location)
+             .id()
+             .field("name", .string, .required)
+             .field("url", .string, .required)
+             .field("lat", .double, .required)
+             .field("long", .double, .required)
+             .field("category_id", .uuid, .references(
+                Schema.locationCategory, "id", onDelete: .setNull, onUpdate: .cascade
+             ))
+             .create()
+    }
+    func revert(on database: Database) async throws {
+        try await database.schema(Schema.location).delete()
+    }
+
+}

--- a/Sources/App/Features/Locations/Model/Location.swift
+++ b/Sources/App/Features/Locations/Model/Location.swift
@@ -17,8 +17,8 @@ final class Location: Codable, Model, Content {
     @Field(key: "lat")
     var lat: Double
 
-    @Field(key: "long")
-    var long: Double
+    @Field(key: "lon")
+    var lon: Double
 
     @Field(key: "url")
     var url: String

--- a/Sources/App/Features/Locations/Model/Location.swift
+++ b/Sources/App/Features/Locations/Model/Location.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Fluent
+import Vapor
+
+final class Location: Codable, Model, Content {
+
+    static let schema = Schema.location
+
+    typealias IDValue = UUID
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Field(key: "name")
+    var name: String
+
+    @Field(key: "lat")
+    var lat: Double
+
+    @Field(key: "long")
+    var long: Double
+
+    @Field(key: "url")
+    var url: String
+
+    @Parent(key: "category_id")
+    var category: LocationCategory
+}

--- a/Sources/App/Features/Locations/Model/LocationResponse.swift
+++ b/Sources/App/Features/Locations/Model/LocationResponse.swift
@@ -1,0 +1,10 @@
+import Foundation
+import Vapor
+
+struct LocationResponse: Codable, Content {
+    var id: UUID
+    var name: String
+    var lat: Double
+    var long: Double
+    var url: String
+}

--- a/Sources/App/Features/Locations/Model/LocationResponse.swift
+++ b/Sources/App/Features/Locations/Model/LocationResponse.swift
@@ -5,6 +5,6 @@ struct LocationResponse: Codable, Content {
     var id: UUID
     var name: String
     var lat: Double
-    var long: Double
+    var lon: Double
     var url: String
 }

--- a/Sources/App/Features/Locations/Transformers/LocationTransformer.swift
+++ b/Sources/App/Features/Locations/Transformers/LocationTransformer.swift
@@ -10,7 +10,7 @@ enum LocationTransformer: Transformer {
             id: id,
             name: entity.name,
             lat: entity.lat,
-            long: entity.long,
+            lon: entity.lon,
             url: entity.url
         )
     }

--- a/Sources/App/Features/Locations/Transformers/LocationTransformer.swift
+++ b/Sources/App/Features/Locations/Transformers/LocationTransformer.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+enum LocationTransformer: Transformer {
+    static func transform(_ entity: Location?) -> LocationResponse? {
+        guard let entity = entity, let id = entity.id else {
+            return nil
+        }
+
+        return LocationResponse(
+            id: id,
+            name: entity.name,
+            lat: entity.lat,
+            long: entity.long,
+            url: entity.url
+        )
+    }
+}

--- a/Sources/App/Features/Schema.swift
+++ b/Sources/App/Features/Schema.swift
@@ -30,4 +30,12 @@ enum Schema {
     static var sponsor: String {
         return "sponsors"
     }
+
+    static var location: String {
+        return "locations"
+    }
+
+    static var locationCategory: String {
+        return "locationCategories"
+    }
 }

--- a/Sources/App/Migrations.swift
+++ b/Sources/App/Migrations.swift
@@ -40,6 +40,10 @@ class Migrations {
         // Session Record Migrations
         
         app.migrations.add(SessionRecord.migration)
+
+        // Location migrations
+        app.migrations.add(LocationCategoryMigrationV1())
+        app.migrations.add(LocationMigrationV1())
         
         do {
             struct DatabaseError: Error {}

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -71,6 +71,7 @@ func routes(_ app: Application) throws {
     try apiRoutes.grouped("activities").register(collection: ActivityAPIController())
     try apiRoutes.grouped("sponsors").register(collection: SponsorAPIController())
     try apiRoutes.grouped("schedule").register(collection: ScheduleAPIController())
+    try apiRoutes.grouped("local").register(collection: LocalAPIController())
 
     // MARK: - Admin Routes
     


### PR DESCRIPTION
Adds the data for the local endpoint. It doesn't add a CMS for it, but given this is unlikely to change im ok with that one personally 😄 

Should unblock local page being worked on 🙏🏻

Sample response:

```swift
{
    "data": [
        {
            "symbolName": "wineglass.fill",
            "id": "BD99AE67-B891-4EF0-B22A-81F89926555B",
            "name": "Wine",
            "locations": [
                {
                    "id": "BD99AE67-B891-4EF0-B22A-81F89926555B",
                    "lat": 53.796072000000002,
                    "long": -1.544208,
                    "name": "Alchemist",
                    "url": "https://thealchemist.uk.com/venues/leeds-trinity/"
                }
            ]
        }
    ]
}
```

Really simple response, just enough to show litle pins with URLs. Allows for design freedom too as you can re-use the category symbols.