### PR TITLE
Add the option to configure a second speaker

### DIFF
--- a/Public/css/style.css
+++ b/Public/css/style.css
@@ -435,12 +435,19 @@ ul.tickets li a {
     height: 300px;
 }
 
+
 .speaker-grid-element-image {
     object-fit: cover;
     width: 100%;
     height: 100%;
     background-color: rgba(255, 126, 7, 0.4);
-  }
+}
+
+.dual-speaker-image-container > img {
+    width: 48%;
+    height: 100%;
+    display: inline-block;
+}
 
 .speaker-grid-element-info { 
   display: inline-block;

--- a/Public/css/style.css
+++ b/Public/css/style.css
@@ -443,12 +443,6 @@ ul.tickets li a {
     background-color: rgba(255, 126, 7, 0.4);
 }
 
-.dual-speaker-image-container > img {
-    width: 48%;
-    height: 100%;
-    display: inline-block;
-}
-
 .speaker-grid-element-info { 
   display: inline-block;
   padding-left: 20px;

--- a/Resources/Views/Admin/presentations.leaf
+++ b/Resources/Views/Admin/presentations.leaf
@@ -2,7 +2,11 @@
 <ul class="list-group">
     #for(presentation in presentations):
         <li class="list-group-item d-flex justify-content-between align-items-center">
+            #if(presentation.secondSpeaker):
+            "#(presentation.title)" by #(presentation.speaker.name), #(presentation.secondSpeaker.name)
+            #else:
             "#(presentation.title)" by #(presentation.speaker.name)
+            #endif
             <span class="badge badge-primary badge-pill">
                 <a href="#">🗑</a>
                 &nbsp

--- a/Resources/Views/Authentication/presentation_form.leaf
+++ b/Resources/Views/Authentication/presentation_form.leaf
@@ -23,6 +23,20 @@
                   </option>
                 #endfor
                 </select>
+                <br/>
+                <div class="form-group form-check">
+                <input type="checkbox" class="form-check-input" id="enableSecondSpeaker" data-toggle="toggle">
+                <label class="form-check-label" for="enableSecondSpeaker">Second Speaker</label>
+                </div>
+                <br>
+                <label for="secondSpeakerID" class="form-label secondSpeaker">Speaker Two</label>
+                <select name="secondSpeakerID" class="form-control secondSpeaker">
+                #for(speaker in speakers):
+                  <option #if(speaker.id == presentation.secondSpeaker.id): selected #endif id="secondSpeakerID" name="secondSpeakerID" value=#(speaker.id)>
+                    #(speaker.name)
+                  </option>
+                #endfor
+                </select>
                 <br>
                 <label for="event" class="form-label">Event</label>
                 <select name="eventID" class="form-control">
@@ -56,6 +70,22 @@
             function setEventDate(date) {
                 window.EventDate = date;
             }
+            function updateForSecondSpeaker(enabled) {
+                console.log(enabled)
+                if (enabled) {
+                    $(".secondSpeaker").show();
+                } else {
+                    $(".secondSpeaker").hide();
+                }
+            }
+            $(document).ready(function(){
+              updateForSecondSpeaker(#(hasSecondSpeaker))
+              $("#enableSecondSpeaker").prop("checked", #(hasSecondSpeaker))
+              $("#enableSecondSpeaker").on("change", function(e){
+                var enabled = $(this).prop("checked") == true
+                updateForSecondSpeaker(enabled)
+              });
+            });
         </script>
         #extend("Shared/_footer")
     #endexport

--- a/Resources/Views/Home/_schedule.leaf
+++ b/Resources/Views/Home/_schedule.leaf
@@ -41,7 +41,14 @@
           
             <div class="col-md-4">
                 #if(slot.presentation):
+                    #if(slot.presentation.secondSpeaker):
+                    <div class="dual-speaker-image-container">
                     <img class="speaker-grid-element-image" src="https://swiftleeds-speakers.s3.eu-west-2.amazonaws.com/#(slot.presentation.speaker.profileImage)"/>
+                    <img class="speaker-grid-element-image" src="https://swiftleeds-speakers.s3.eu-west-2.amazonaws.com/#(slot.presentation.secondSpeaker.profileImage)"/>
+                    </div>
+                    #else:
+                    <img class="speaker-grid-element-image" src="https://swiftleeds-speakers.s3.eu-west-2.amazonaws.com/#(slot.presentation.speaker.profileImage)"/>
+                    #endif
                 #elseif(slot.activity):
                     <img class="speaker-grid-element-image" src="https://swiftleeds-speakers.s3.eu-west-2.amazonaws.com/#(slot.activity.image)"/>
                 #endif
@@ -59,6 +66,10 @@
               <br />
                 #if(slot.presentation):
                     <strong>#(slot.presentation.speaker.name)</strong> / #(slot.presentation.speaker.organisation)
+                    <br />
+                    #if(slot.presentation.secondSpeaker):
+                    <strong>#(slot.presentation.secondSpeaker.name)</strong> / #(slot.presentation.secondSpeaker.organisation)
+                    #endif
                 #endif
             </div>
             </div>

--- a/Sources/App/Features/Local/LocalAPIController.swift
+++ b/Sources/App/Features/Local/LocalAPIController.swift
@@ -23,10 +23,3 @@ struct LocalAPIController: RouteCollection {
         return try await response.encodeResponse(for: request)
     }
 }
-
-private extension ScheduleAPIController {
-    enum ScheduleAPIError: Error {
-        case notFound
-        case transformFailure
-    }
-}

--- a/Sources/App/Features/Presentations/Controllers/PresentationAPIController.swift
+++ b/Sources/App/Features/Presentations/Controllers/PresentationAPIController.swift
@@ -5,9 +5,11 @@ struct PresentationAPIController: RouteCollection {
     
     private struct FormInput: Content {
         let speakerID: String
+        let secondSpeakerID: String?
         let eventID: String
         let title: String
         let synopsis: String
+        let enableSecondSpeaker: Bool?
     }
     
     func boot(routes: RoutesBuilder) throws {
@@ -21,10 +23,11 @@ struct PresentationAPIController: RouteCollection {
         guard let speaker = try await Speaker.find(UUID(uuidString: input.speakerID), on: request.db) else {
             return request.redirect(to: "/admin")
         }
-        
+
         guard let event = try await Event.find(.init(uuidString: input.eventID), on: request.db) else {
             return request.redirect(to: "/admin")
         }
+
         
         let presentation = Presentation(
             id: .generateRandom(),
@@ -36,6 +39,15 @@ struct PresentationAPIController: RouteCollection {
         
         presentation.$speaker.id = try speaker.requireID()
         presentation.$event.id = try event.requireID()
+
+        if let secondSpeakerID = input.secondSpeakerID, (input.enableSecondSpeaker ?? false) {
+            guard let secondSpeaker = try await Speaker.find(UUID(uuidString: secondSpeakerID), on: request.db) else {
+                return request.redirect(to: "/admin")
+            }
+            presentation.$secondSpeaker.id = try secondSpeaker.requireID()
+        } else {
+            presentation.$secondSpeaker.id = nil
+        }
         
         try await presentation.create(on: request.db)
         
@@ -64,6 +76,15 @@ struct PresentationAPIController: RouteCollection {
         
         presentation.$speaker.id = try speaker.requireID()
         presentation.$event.id = try event.requireID()
+
+        if let secondSpeakerID = input.secondSpeakerID, (input.enableSecondSpeaker ?? false) {
+            guard let secondSpeaker = try await Speaker.find(UUID(uuidString: secondSpeakerID), on: request.db) else {
+                return request.redirect(to: "/admin")
+            }
+            presentation.$secondSpeaker.id = try secondSpeaker.requireID()
+        } else {
+            presentation.$secondSpeaker.id = nil
+        }
         
         try await presentation.update(on: request.db)
         

--- a/Sources/App/Features/Presentations/Controllers/PresentationViewController.swift
+++ b/Sources/App/Features/Presentations/Controllers/PresentationViewController.swift
@@ -14,6 +14,7 @@ struct PresentationViewController: RouteCollection {
         let presentation: Presentation?
         let speakers: [Speaker]
         let events: [Event]
+        let hasSecondSpeaker: Bool
     }
     
     func boot(routes: RoutesBuilder) throws {
@@ -28,7 +29,7 @@ struct PresentationViewController: RouteCollection {
         
         let speakers = try await Speaker.query(on: request.db).all()
         let events = try await Event.query(on: request.db).all()
-        let context = PresentationContext(presentation: nil, speakers: speakers, events: events)
+        let context = PresentationContext(presentation: nil, speakers: speakers, events: events, hasSecondSpeaker: false)
         
         return try await request.view.render("Authentication/presentation_form", context)
     }
@@ -41,10 +42,10 @@ struct PresentationViewController: RouteCollection {
         guard let presentation = try await Presentation.find(request.parameters.get("id"), on: request.db) else {
             throw Abort(.notFound)
         }
-        
+
         let speakers = try await Speaker.query(on: request.db).all()
         let events = try await Event.query(on: request.db).all()
-        let context = PresentationContext(presentation: presentation, speakers: speakers, events: events)
+        let context = PresentationContext(presentation: presentation, speakers: speakers, events: events, hasSecondSpeaker: presentation.$secondSpeaker.id != nil)
         
         return try await request.view.render("Authentication/presentation_form", context)
     }

--- a/Sources/App/Features/Presentations/Models/Migrations/Presentation+Migration+V2.swift
+++ b/Sources/App/Features/Presentations/Models/Migrations/Presentation+Migration+V2.swift
@@ -1,0 +1,16 @@
+import Fluent
+
+class PresentationMigrationV2: AsyncMigration {
+
+    func prepare(on database: Database) async throws {
+        try await database.schema(Schema.presentation)
+            .field("speaker_two_id", .uuid, .references(Schema.speaker, "id", onDelete: .setNull, onUpdate: .cascade))
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema(Schema.activity)
+            .deleteField("speaker_two_id")
+            .update()
+    }
+}

--- a/Sources/App/Features/Presentations/Models/Migrations/Presentation+Migration+V2.swift
+++ b/Sources/App/Features/Presentations/Models/Migrations/Presentation+Migration+V2.swift
@@ -9,7 +9,7 @@ class PresentationMigrationV2: AsyncMigration {
     }
 
     func revert(on database: Database) async throws {
-        try await database.schema(Schema.activity)
+        try await database.schema(Schema.presentation)
             .deleteField("speaker_two_id")
             .update()
     }

--- a/Sources/App/Features/Presentations/Models/Presentation.swift
+++ b/Sources/App/Features/Presentations/Models/Presentation.swift
@@ -31,6 +31,9 @@ final class Presentation: Model, Content {
     
     @Parent(key: "speaker_id")
     var speaker: Speaker
+
+    @OptionalParent(key: "speaker_two_id")
+    var secondSpeaker: Speaker?
     
     @Parent(key: "event_id")
     public var event: Event

--- a/Sources/App/Features/Presentations/Models/PresentationResponse+V2.swift
+++ b/Sources/App/Features/Presentations/Models/PresentationResponse+V2.swift
@@ -1,0 +1,17 @@
+//
+//  PresentationResponse+V2.swift
+//  
+//
+//  Created by Alex Logan on 18/08/2022.
+//
+
+import Foundation
+import Vapor
+
+struct PresentationResponseV2: Content {
+    let id: UUID
+    let title: String
+    let synopsis: String
+    let image: String?
+    var speakers: [SpeakerResponse] = []
+}

--- a/Sources/App/Features/Presentations/Transformers/PresentationTransformerV2.swift
+++ b/Sources/App/Features/Presentations/Transformers/PresentationTransformerV2.swift
@@ -1,0 +1,37 @@
+//
+//  PresentationTransformerV2.swift
+//  
+//
+//  Created by Alex Logan on 18/08/2022.
+//
+
+import Foundation
+
+enum PresentationTransformerV2: Transformer {
+    static func transform(_ entity: Presentation?) -> PresentationResponseV2? {
+        guard let entity = entity, let id = entity.id else { return nil }
+
+        let speaker: SpeakerResponse?
+        let secondSpeaker: SpeakerResponse?
+
+        if let speakerEntity = entity.$speaker.value {
+            speaker = SpeakerTransformer.transform(speakerEntity)
+        } else {
+            speaker = nil
+        }
+
+        if let secondSpeakerEntity = entity.$secondSpeaker.value {
+            secondSpeaker = SpeakerTransformer.transform(secondSpeakerEntity)
+        } else {
+            secondSpeaker = nil
+        }
+
+        return PresentationResponseV2(
+            id: id,
+            title: entity.title,
+            synopsis: entity.synopsis,
+            image: entity.image,
+            speakers: [speaker, secondSpeaker].compactMap { $0 }
+        )
+    }
+}

--- a/Sources/App/Features/Schedule/Models/ScheduleResponse+V2.swift
+++ b/Sources/App/Features/Schedule/Models/ScheduleResponse+V2.swift
@@ -1,0 +1,14 @@
+//
+//  ScheduleResponse+V2.swift
+//
+//
+//  Created by Alex Logan on 02/08/2022.
+//
+
+import Foundation
+import Vapor
+
+struct ScheduleResponseV2: Content {
+    let event: EventResponse
+    let slots: [SlotResponseV2]
+}

--- a/Sources/App/Features/Schedule/ScheduleAPIController+V2.swift
+++ b/Sources/App/Features/Schedule/ScheduleAPIController+V2.swift
@@ -1,15 +1,14 @@
 //
-//  ScheduleAPIController.swift
-//  
+//  ScheduleAPIController+V2.swift
 //
-//  Created by Alex Logan on 25/07/2022.
+//
+//  Created by Alex Logan on 18/08/2022.
 //
 
 import Vapor
 import Fluent
 
-
-struct ScheduleAPIController: RouteCollection {
+struct ScheduleAPIControllerV2: RouteCollection {
     func boot(routes: RoutesBuilder) throws {
         routes.get("", use: onGet)
     }
@@ -23,30 +22,23 @@ struct ScheduleAPIController: RouteCollection {
                 slots
                     .with(\.$activity)
                     .with(\.$presentation, { presentation in
-                        presentation.with(\.$speaker)
+                        presentation.with(\.$speaker).with(\.$secondSpeaker)
                     })
             })
             .first()
 
         guard let event = eventWithSlots else {
-            throw ScheduleAPIError.notFound
+            throw ScheduleAPIController.ScheduleAPIError.notFound
         }
 
-        guard let schedule = ScheduleTransformer.transform(event: event, slots: event.slots) else {
-            throw ScheduleAPIError.transformFailure
+        guard let schedule = ScheduleTransformerV2.transform(event: event, slots: event.slots) else {
+            throw ScheduleAPIController.ScheduleAPIError.transformFailure
         }
 
         let response = GenericResponse(
             data: schedule
         )
-        
-        return try await response.encodeResponse(for: request)
-    }
-}
 
-extension ScheduleAPIController {
-    enum ScheduleAPIError: Error {
-        case notFound
-        case transformFailure
+        return try await response.encodeResponse(for: request)
     }
 }

--- a/Sources/App/Features/Schedule/Transformer/ScheduleTransformer+V2.swift
+++ b/Sources/App/Features/Schedule/Transformer/ScheduleTransformer+V2.swift
@@ -1,6 +1,6 @@
 //
-//  ScheduleTransformer.swift
-//  
+//  ScheduleTransformer+V2.swift
+//
 //
 //  Created by Alex Logan on 02/08/2022.
 //
@@ -8,12 +8,12 @@
 import Foundation
 
 // A unique transformer as it doesn't actually represent an entity
-enum ScheduleTransformer {
-    static func transform(event: Event, slots: [Slot]) -> ScheduleResponse? {
+enum ScheduleTransformerV2 {
+    static func transform(event: Event, slots: [Slot]) -> ScheduleResponseV2? {
         guard let eventResponse = EventTransformer.transform(event) else { return nil }
-        return ScheduleResponse(
+        return ScheduleResponseV2(
             event: eventResponse,
-            slots: slots.compactMap(SlotTransformer.transform(_:)).sorted(by: {
+            slots: slots.compactMap(SlotTransformerV2.transform(_:)).sorted(by: {
                 $0.startTime < $1.startTime
             })
         )

--- a/Sources/App/Features/Slots/Models/SlotResponse+V2.swift
+++ b/Sources/App/Features/Slots/Models/SlotResponse+V2.swift
@@ -1,0 +1,17 @@
+//
+//  SlotResponse+V2.swift
+//  
+//
+//  Created by Alex Logan on 18/08/2022.
+//
+
+import Foundation
+import Vapor
+
+struct SlotResponseV2: Content {
+    let id: UUID
+    let startTime: String
+    let duration: Double
+    let presentation: PresentationResponseV2?
+    let activity: ActivityResponse?
+}

--- a/Sources/App/Features/Slots/Transformers/SlotTransformer+V2.swift
+++ b/Sources/App/Features/Slots/Transformers/SlotTransformer+V2.swift
@@ -1,0 +1,37 @@
+//
+//  SlotTransformer+V2.swift
+//
+//
+//  Created by Alex Logan on 25/07/2022.
+//
+
+import Foundation
+
+enum SlotTransformerV2: Transformer {
+    static func transform(_ entity: Slot?) -> SlotResponseV2? {
+        guard let entity = entity, let id = entity.id else { return nil }
+
+        let presentation: PresentationResponseV2?
+        let activity: ActivityResponse?
+
+        if let presentationEntity = entity.$presentation.value {
+            presentation = PresentationTransformerV2.transform(presentationEntity)
+        } else {
+            presentation = nil
+        }
+
+        if let activityEntity = entity.$activity.value {
+            activity = ActivityTransformer.transform(activityEntity)
+        } else {
+            activity = nil
+        }
+
+        return .init(
+            id: id,
+            startTime: entity.startDate,
+            duration: entity.duration,
+            presentation: presentation,
+            activity: activity
+        )
+    }
+}

--- a/Sources/App/Migrations.swift
+++ b/Sources/App/Migrations.swift
@@ -44,6 +44,10 @@ class Migrations {
         // Location migrations
         app.migrations.add(LocationCategoryMigrationV1())
         app.migrations.add(LocationMigrationV1())
+
+        // Dual Speaker Migrations
+
+        app.migrations.add(PresentationMigrationV2())
         
         do {
             struct DatabaseError: Error {}


### PR DESCRIPTION
Adds the basic work needed to support a second speaker. I've done it this way to achive the desired effect without any complex migrations or huge changes, allowing for a pending launch to not be delayed.

### Changes

- Adds the second speaker to the presentation model
- Adds a toggle to enable a second speaker on the presentation form
- Adds UI for a second speaker on the scheudle ( just splits the image space )
- Adds a v2 endpoint so you can now get multiple speakers

I could not work out a way to stop you selecting the same thing twice.


-- 
visuals

Images will work on the site :)

| Form/Admin | 
| - | 
|<img width="1038" alt="Screenshot 2022-08-18 at 17 28 13" src="https://user-images.githubusercontent.com/13989549/185447900-5148ef4b-8d60-4baa-96df-a88e07f5b42b.png">
<img width="1410" alt="Screenshot 2022-08-18 at 17 35 14" src="https://user-images.githubusercontent.com/13989549/185447954-a71fbf89-d537-43a5-98fa-c9b9d7072874.png">|
 
| Schedule |
| - | 
|<img width="1341" alt="Screenshot 2022-08-18 at 17 27 51" src="https://user-images.githubusercontent.com/13989549/185447753-026c651b-39ca-4cbc-ae7a-fe9778078a8b.png">
<img width="1400" alt="Screenshot 2022-08-18 at 17 27 53" src="https://user-images.githubusercontent.com/13989549/185447761-db02cf36-d627-4f3a-867c-c1b0aec975a9.png">|
--

--

Sample response from v2 endpoint ( URLS not valid )

```json
{
    "data": {
        "event": {
            "id": "CAA79056-DB6B-42B7-8AA9-D7AADD39F1B6",
            "name": "one",
            "location": "asdasd",
            "date": "18-08-2022"
        },
        "slots": [
            {
                "startTime": "01:05",
                "id": "07AB4264-9AAE-4703-A7D7-891ABF6CECEF",
                "presentation": {
                    "speakers": [
                        {
                            "profileImage": "https://goaway.s3.eu-west-2.amazonaws.com/Alex Logan_Arc.png-E347937B-6EE7-4CEB-92DB-C622EC974B27",
                            "twitter": "dasdasd",
                            "id": "4CD23115-52FD-4AED-A809-842221AC55C4",
                            "presentations": [],
                            "biography": "A",
                            "organisation": "asdasd",
                            "name": "A"
                        },
                        {
                            "profileImage": "https://goaway.s3.eu-west-2.amazonaws.com/Alex Logan_Arc_2.png-5AAB671C-F5CC-4DE3-A299-973C38307676",
                            "twitter": "B",
                            "id": "4C56AFDF-DDC4-4A52-B516-C21E0301C99C",
                            "presentations": [],
                            "biography": "B",
                            "organisation": "B",
                            "name": "B"
                        }
                    ],
                    "id": "30204684-EB1E-4CD3-8381-1CEA879A49A1",
                    "title": "AYYYYYY",
                    "synopsis": "dasdasd"
                },
                "duration": 9
            }
        ]
    }
}
```
