### PR TITLE
Fix wrong schedule api version

### DIFF
--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -78,12 +78,8 @@ func routes(_ app: Application) throws {
     try apiRoutes.grouped("slots").register(collection: SlotAPIController())
     try apiRoutes.grouped("activities").register(collection: ActivityAPIController())
     try apiRoutes.grouped("sponsors").register(collection: SponsorAPIController())
-    try apiRoutes.grouped("schedule").register(collection: ScheduleAPIController())
+    try apiRoutes.grouped("schedule").register(collection: ScheduleAPIControllerV2())
     try apiRoutes.grouped("local").register(collection: LocalAPIController())
-
-    let apiTwoRoutes = app.grouped("api", "v2")
-
-    try apiTwoRoutes.grouped("schedule").register(collection: ScheduleAPIControllerV2())
 
     // MARK: - Admin Routes
     


### PR DESCRIPTION
A mistake was made using v2 for the API use for retrieving the schedule.  As the app is still in development there is no reason to move to v2.  