### PR TITLE
Add Slido URL option to a Presentation

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: Run migrate -y
 web: Run serve --env production --hostname 0.0.0.0 --port $PORT

--- a/Resources/Views/Authentication/presentation_form.leaf
+++ b/Resources/Views/Authentication/presentation_form.leaf
@@ -60,6 +60,10 @@
                   <label for="formFile" class="form-label">Presentation image</label>
                   <input class="form-control" type="file" id="image">
                 </div>
+                <div class="mb-3">
+                  <label for="slidoURL" class="form-label">Slido URL</label>
+                  <input value="#(presentation.slidoURL)" class="form-control" name="slidoURL" id="slidoURL">
+                </div>
                 <button type="submit" class="btn btn-primary">Submit</button>
             </form>
             <div class="col-6">

--- a/Resources/Views/Authentication/slot_form.leaf
+++ b/Resources/Views/Authentication/slot_form.leaf
@@ -38,7 +38,7 @@
                 <select name="activityID" class="form-control activity">
                 <option disabled selected value> -- select an option -- </option>
                 #for(activity in activities):
-                  <option #if(activities.id == slot.activity.id): selected #endif id="activityID" name="activityID" value=#(activity.id)>
+                  <option #if(activity.id == slot.activity.id): selected #endif id="activityID" name="activityID" value=#(activity.id)>
                     #(activity.title) - #(activity.subtitle)
                   </option>
                 #endfor

--- a/Sources/App/Features/Presentations/Controllers/PresentationAPIController.swift
+++ b/Sources/App/Features/Presentations/Controllers/PresentationAPIController.swift
@@ -10,10 +10,11 @@ struct PresentationAPIController: RouteCollection {
         let title: String
         let synopsis: String
         let enableSecondSpeaker: Bool?
+        let slidoURL: String?
     }
     
     func boot(routes: RoutesBuilder) throws {
-        routes.post("", use: onPost)
+        routes.post(use: onPost)
         routes.post(":id", use: onEdit)
     }
 
@@ -34,7 +35,8 @@ struct PresentationAPIController: RouteCollection {
             title: input.title,
             synopsis: input.synopsis,
             image: nil,
-            isTBA: false
+            isTBA: false,
+            slidoURL: input.slidoURL
         )
         
         presentation.$speaker.id = try speaker.requireID()
@@ -73,6 +75,7 @@ struct PresentationAPIController: RouteCollection {
         presentation.synopsis = input.synopsis
         presentation.image = nil
         presentation.isTBA = false
+        presentation.slidoURL = input.slidoURL
         
         presentation.$speaker.id = try speaker.requireID()
         presentation.$event.id = try event.requireID()

--- a/Sources/App/Features/Presentations/Models/Migrations/Presentation+Migration+V3.swift
+++ b/Sources/App/Features/Presentations/Models/Migrations/Presentation+Migration+V3.swift
@@ -1,0 +1,15 @@
+import Fluent
+
+class PresentationMigrationV3: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema(Schema.presentation)
+            .field("slido_url", .string)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema(Schema.presentation)
+            .deleteField("slido_url")
+            .update()
+    }
+}

--- a/Sources/App/Features/Presentations/Models/Presentation.swift
+++ b/Sources/App/Features/Presentations/Models/Presentation.swift
@@ -43,14 +43,18 @@ final class Presentation: Model, Content {
     
     @Field(key: "is_tba")
     var isTBA: Bool
+
+    @Field(key: "slido_url")
+    var slidoURL: String?
     
     init() { }
     
-    init(id: IDValue?, title: String, synopsis: String, image: String?, isTBA: Bool) {
+    init(id: IDValue?, title: String, synopsis: String, image: String?, isTBA: Bool, slidoURL: String?) {
         self.id = id
         self.title = title
         self.synopsis = synopsis
         self.image = image
         self.isTBA = isTBA
+        self.slidoURL = slidoURL
     }
 }

--- a/Sources/App/Features/Presentations/Models/PresentationResponse+V2.swift
+++ b/Sources/App/Features/Presentations/Models/PresentationResponse+V2.swift
@@ -14,4 +14,5 @@ struct PresentationResponseV2: Content {
     let synopsis: String
     let image: String?
     var speakers: [SpeakerResponse] = []
+    let slidoURL: String?
 }

--- a/Sources/App/Features/Presentations/Models/PresentationResponse.swift
+++ b/Sources/App/Features/Presentations/Models/PresentationResponse.swift
@@ -14,4 +14,5 @@ struct PresentationResponse: Content {
     let synopsis: String
     let image: String?
     let speaker: SpeakerResponse?
+    let slidoURL: String?
 }

--- a/Sources/App/Features/Presentations/Transformers/PresentationTransformer.swift
+++ b/Sources/App/Features/Presentations/Transformers/PresentationTransformer.swift
@@ -24,7 +24,8 @@ enum PresentationTransformer: Transformer {
             title: entity.title,
             synopsis: entity.synopsis,
             image: entity.image,
-            speaker: speaker
+            speaker: speaker,
+            slidoURL: entity.slidoURL
         )
     }
 }

--- a/Sources/App/Features/Presentations/Transformers/PresentationTransformerV2.swift
+++ b/Sources/App/Features/Presentations/Transformers/PresentationTransformerV2.swift
@@ -31,7 +31,8 @@ enum PresentationTransformerV2: Transformer {
             title: entity.title,
             synopsis: entity.synopsis,
             image: entity.image,
-            speakers: [speaker, secondSpeaker].compactMap { $0 }
+            speakers: [speaker, secondSpeaker].compactMap { $0 },
+            slidoURL: entity.slidoURL
         )
     }
 }

--- a/Sources/App/Migrations.swift
+++ b/Sources/App/Migrations.swift
@@ -46,8 +46,10 @@ class Migrations {
         app.migrations.add(LocationMigrationV1())
 
         // Dual Speaker Migrations
-
         app.migrations.add(PresentationMigrationV2())
+
+        // Addition of optional Slido URL
+        app.migrations.add(PresentationMigrationV3())
         
         do {
             struct DatabaseError: Error {}


### PR DESCRIPTION
Adds a new optional Slide URL entry for a Presentation and passes this back if it exists to the schedule API response.  
Also added `release: Run migrate -y` to the `Procfile` to allow migrations to happen when releasing.  