### PR TITLE
Refactor presentation form

### DIFF
--- a/Resources/Views/Authentication/presentation_form.leaf
+++ b/Resources/Views/Authentication/presentation_form.leaf
@@ -25,12 +25,12 @@
                 </select>
                 <br/>
                 <div class="form-group form-check">
-                <input type="checkbox" class="form-check-input" id="enableSecondSpeaker" data-toggle="toggle">
+                <input type="checkbox" class="form-check-input" id="enableSecondSpeaker" data-toggle="toggle" checked="checked">
                 <label class="form-check-label" for="enableSecondSpeaker">Second Speaker</label>
                 </div>
                 <br>
                 <label for="secondSpeakerID" class="form-label secondSpeaker">Speaker Two</label>
-                <select name="secondSpeakerID" class="form-control secondSpeaker">
+                <select id="secondSpeakerSelect" name="secondSpeakerID" class="form-control secondSpeaker">
                 #for(speaker in speakers):
                   <option #if(speaker.id == presentation.secondSpeaker.id): selected #endif id="secondSpeakerID" name="secondSpeakerID" value=#(speaker.id)>
                     #(speaker.name)
@@ -75,10 +75,12 @@
                 window.EventDate = date;
             }
             function updateForSecondSpeaker(enabled) {
-                console.log(enabled)
                 if (enabled) {
                     $(".secondSpeaker").show();
                 } else {
+                    $("#secondSpeakerSelect").find('option').each(function( index ) {
+                        $(this).attr("selected", false);
+                    });
                     $(".secondSpeaker").hide();
                 }
             }

--- a/Sources/App/Features/Presentations/Controllers/PresentationAPIController.swift
+++ b/Sources/App/Features/Presentations/Controllers/PresentationAPIController.swift
@@ -9,7 +9,6 @@ struct PresentationAPIController: RouteCollection {
         let eventID: String
         let title: String
         let synopsis: String
-        let enableSecondSpeaker: Bool?
         let slidoURL: String?
     }
     
@@ -42,7 +41,7 @@ struct PresentationAPIController: RouteCollection {
         presentation.$speaker.id = try speaker.requireID()
         presentation.$event.id = try event.requireID()
 
-        if let secondSpeakerID = input.secondSpeakerID, (input.enableSecondSpeaker ?? false) {
+        if let secondSpeakerID = input.secondSpeakerID {
             guard let secondSpeaker = try await Speaker.find(UUID(uuidString: secondSpeakerID), on: request.db) else {
                 return request.redirect(to: "/admin")
             }
@@ -80,7 +79,7 @@ struct PresentationAPIController: RouteCollection {
         presentation.$speaker.id = try speaker.requireID()
         presentation.$event.id = try event.requireID()
 
-        if let secondSpeakerID = input.secondSpeakerID, (input.enableSecondSpeaker ?? false) {
+        if let secondSpeakerID = input.secondSpeakerID {
             guard let secondSpeaker = try await Speaker.find(UUID(uuidString: secondSpeakerID), on: request.db) else {
                 return request.redirect(to: "/admin")
             }


### PR DESCRIPTION
If you edit a speaker at the mo, it might delete the second speaker. The reason for the toggle being there initially was that I used the state of that toggle to determine wether I should persist or clear the second speaker. It looks like for some reason the boolean no longer works, so I've pulled it out and instead I'm using a boolean to set the initial state, and JS to clear the selection when you edit but only if you manually un-toggle the second speaker.

I noticed a speaker was missing in the database for the only dual speaker slot we have, so I manually adjusted that.