### PR TITLE
Fix push migrations

### DIFF
--- a/Sources/App/Features/Push/Migrations/PushMigration.swift
+++ b/Sources/App/Features/Push/Migrations/PushMigration.swift
@@ -2,7 +2,7 @@ import Fluent
 
 struct PushMigration: AsyncMigration {
     func prepare(on database: Database) async throws {
-        try await database.schema("tokens")
+        try await database.schema(Schema.token)
             .id()
             .field("token", .string, .required)
             .field("debug", .bool, .required)

--- a/Sources/App/Features/Schema.swift
+++ b/Sources/App/Features/Schema.swift
@@ -7,6 +7,10 @@ enum Schema {
         return "user_tokens"
     }
     
+    static var token: String {
+        return "tokens"
+    }
+    
     static var event: String {
         return "events"
     }

--- a/Sources/App/Migrations.swift
+++ b/Sources/App/Migrations.swift
@@ -47,6 +47,9 @@ class Migrations {
 
         // Dual Speaker Migrations
         app.migrations.add(PresentationMigrationV2())
+        
+        // Add Push migrations
+        app.migrations.add(PushMigration())
 
         // Addition of optional Slido URL
         app.migrations.add(PresentationMigrationV3())
@@ -71,8 +74,5 @@ class Migrations {
         } catch {
             app.logger.error("Failed to migrate DB with error \(error)")
         }
-
-        // MARK: - Push
-        app.migrations.add(PushMigration())
     }
 }

--- a/Sources/App/Migrations.swift
+++ b/Sources/App/Migrations.swift
@@ -48,11 +48,11 @@ class Migrations {
         // Dual Speaker Migrations
         app.migrations.add(PresentationMigrationV2())
         
-        // Add Push migrations
-        app.migrations.add(PushMigration())
-
         // Addition of optional Slido URL
         app.migrations.add(PresentationMigrationV3())
+        
+        // Add Push migrations
+        app.migrations.add(PushMigration())
         
         do {
             struct DatabaseError: Error {}


### PR DESCRIPTION
We raised some concerns with a migration change raised in this [PR](https://github.com/SwiftLeeds/swiftleeds-web/pull/64), and @adamoxley identified that the migration is in the wrong place and that's why it isn't running.

~~This PR adjusts the order to match the order in which they were added to the codebase~~ 

I checked on the live DB and due to the mistake in the order, and the PR migration command, the push migration only actually ran after the slido migration, so I've shifted so they match. This will mean that a local copy of the database will re-create the order as expected on live.