### PR TITLE
Correctly handle Push registration for existing tokens

### DIFF
--- a/Sources/App/Features/Push/Migrations/PushMigration.swift
+++ b/Sources/App/Features/Push/Migrations/PushMigration.swift
@@ -2,7 +2,7 @@ import Fluent
 
 struct PushMigration: AsyncMigration {
     func prepare(on database: Database) async throws {
-        try await database.schema("tokens")
+        try await database.schema(Schema.tokens)
             .id()
             .field("token", .string, .required)
             .field("debug", .bool, .required)
@@ -11,6 +11,6 @@ struct PushMigration: AsyncMigration {
     }
 
     func revert(on database: Database) async throws {
-        try await database.schema("tokens").delete()
+        try await database.schema(Schema.tokens).delete()
     }
 }

--- a/Sources/App/Features/Push/Migrations/PushMigrationV2.swift
+++ b/Sources/App/Features/Push/Migrations/PushMigrationV2.swift
@@ -1,0 +1,15 @@
+import Fluent
+
+struct PushMigrationV2: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema(Schema.tokens)
+            .field("updated_at", .string)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema(Schema.tokens)
+            .deleteField("updated_at")
+            .update()
+    }
+}

--- a/Sources/App/Features/Push/Models/Token.swift
+++ b/Sources/App/Features/Push/Models/Token.swift
@@ -13,6 +13,9 @@ final class Token: Model, Content {
     @Field(key: "debug")
     var debug: Bool
 
+    @Timestamp(key: "updated_at", on: .update, format: .iso8601)
+    var updatedAt: Date?
+
     init() {}
 
     init(id: UUID? = nil, token: String, debug: Bool) {

--- a/Sources/App/Features/Schema.swift
+++ b/Sources/App/Features/Schema.swift
@@ -38,4 +38,8 @@ enum Schema {
     static var locationCategory: String {
         return "locationCategories"
     }
+
+    static var tokens: String {
+        return "tokens"
+    }
 }

--- a/Sources/App/Migrations.swift
+++ b/Sources/App/Migrations.swift
@@ -50,6 +50,10 @@ class Migrations {
 
         // Addition of optional Slido URL
         app.migrations.add(PresentationMigrationV3())
+
+        // MARK: - Push
+        app.migrations.add(PushMigration())
+        app.migrations.add(PushMigrationV2())
         
         do {
             struct DatabaseError: Error {}
@@ -71,8 +75,5 @@ class Migrations {
         } catch {
             app.logger.error("Failed to migrate DB with error \(error)")
         }
-
-        // MARK: - Push
-        app.migrations.add(PushMigration())
     }
 }


### PR DESCRIPTION
Adds logic to update existing tokens (now with updated date) as well as handling new registrations.  
Migrations moved to correct location to allow auto migrate to work as expected.  