### PR TITLE
Set Postgres TLS Configuration in Production

### DIFF
--- a/Sources/App/Migrations.swift
+++ b/Sources/App/Migrations.swift
@@ -56,6 +56,11 @@ class Migrations {
                 throw Abort(.internalServerError, reason: "Invalid PostgreSQL connection URL provided")
             }
             
+            if app.environment.isRelease {
+                // Based on recommended approach from https://devcenter.heroku.com/articles/connecting-heroku-postgres
+                postgresConfig.tlsConfiguration = .makeClientConfiguration()
+            }
+            
             postgresConfig.tlsConfiguration?.certificateVerification = .none
             
             app.databases.use(.postgres(configuration: postgresConfig), as: .psql)


### PR DESCRIPTION
This was recently removed in order to remove the need for TLS checking in local environments, this was done under the documentation provided by Postgres NIO which specifies that the client TLS configuration is defined automatically when the connection string (which comes from the DATABASE_URL environment variable) contains `ssl=true` or `sslmode=require`.

On reading Heroku's documentation (https://devcenter.heroku.com/articles/connecting-heroku-postgres) they acknowledge that, in production, applications almost always must specify these parameters but in their words 'You must add this parameter in code rather than editing the config var directly'.

As such, this is a partial revert but instead now wrap it with an environment check for production. This marries up to Heroku documentation.