### PR TITLE
Patch markdown lists styling

### DIFF
--- a/Public/css/style.css
+++ b/Public/css/style.css
@@ -620,3 +620,9 @@ ul.tickets li a {
         grid-template-columns: 1fr;
     }
 }
+
+/* Markdown */
+
+.markdown li {
+  list-style-type: inherit;
+}

--- a/Resources/Views/Home/_schedule.leaf
+++ b/Resources/Views/Home/_schedule.leaf
@@ -56,7 +56,7 @@
             
             <br />
             <br />
-            <div class="col-md-4 col-lg">
+            <div class="col-md-4 col-lg markdown">
                 #if(slot.presentation):
                     #markdown(slot.presentation.synopsis)
                 #elseif(slot.activity):


### PR DESCRIPTION
Currently markdown lists do not display accurately due to an over-zealous CSS rule. I've added a new class that allows us to scope styling just to these markdown fields.

![image](https://user-images.githubusercontent.com/15193942/201135202-f245cf0b-10d8-4a7d-b351-b5db463f55db.png)
