### PR TITLE
add ability to disable/enable aasa

### DIFF
--- a/Public/.well-known/apple-app-site-association
+++ b/Public/.well-known/apple-app-site-association
@@ -9,7 +9,11 @@
         "details": [
             {
                 "appID": "K33K6V7FBA.uk.co.swiftleeds.SwiftLeeds",
-                "paths": [ "*", "/" ]
+                "paths": [
+                    "NOT /drop-in/*",
+                    "*",
+                    "/"
+                ]
             }
         ]
     }

--- a/Sources/App/Middleware/AppleAppSiteAssociationMiddleware.swift
+++ b/Sources/App/Middleware/AppleAppSiteAssociationMiddleware.swift
@@ -6,8 +6,12 @@ struct AppleAppSiteAssociationMiddleware: AsyncMiddleware {
             return try await next.respond(to: request)
         }
 
-        let response = try await next.respond(to: request)
-        response.headers.add(name: "content-type", value: "application/json")
-        return response
+        if Environment.get("ENABLE_AASA") == "true" {
+            let response = try await next.respond(to: request)
+            response.headers.add(name: "content-type", value: "application/json")
+            return response
+        } else {
+            return Response(status: .notFound)
+        }
     }
 }


### PR DESCRIPTION
disabled by default (returns a 404)

commenting out the middleware wouldn't work, just makes the file invalid which makes Apple grumpy.