### PR TITLE
Wire API and home screen to use 'isCurrent' event

### DIFF
--- a/Resources/Views/Home/home.leaf
+++ b/Resources/Views/Home/home.leaf
@@ -43,10 +43,8 @@
     #endif
     <br />
     #if(count(slots) > 0):
-        #if(!conferenceEnded):
-            <br/>
-            #extend("Home/_schedule")
-        #endif
+        <br/>
+        #extend("Home/_schedule")
     #endif
     <br/>
     #extend("Home/_location")

--- a/Sources/App/Context/HomeContext.swift
+++ b/Sources/App/Context/HomeContext.swift
@@ -13,7 +13,6 @@ struct HomeContext: Content {
     var speakers: [Speaker] = []
     var cfpEnabled: Bool = false
     var ticketsEnabled: Bool = false
-    var conferenceEnded: Bool = true
     var slots: [Slot] = []
     var platinumSponsors: [Sponsor] = []
     var silverSponsors: [Sponsor] = []

--- a/Sources/App/Features/Events/Models/Event.swift
+++ b/Sources/App/Features/Events/Models/Event.swift
@@ -30,3 +30,13 @@ final class Event: Model, Content {
     
     init() {}
 }
+
+extension Event {
+    static func getCurrent(on db: Database) async throws -> Event {
+        guard let event = try await Event.query(on: db).filter(\.$isCurrent == true).first() else {
+            throw Abort(.notFound, reason: "could not locate current event")
+        }
+        
+        return event
+    }
+}

--- a/Sources/App/Features/Slots/Transformers/SlotTransformer+V2.swift
+++ b/Sources/App/Features/Slots/Transformers/SlotTransformer+V2.swift
@@ -9,7 +9,7 @@ enum SlotTransformerV2: Transformer {
         let presentation: PresentationResponseV2?
         let activity: ActivityResponse?
 
-        if let presentationEntity = entity.$presentation.value {
+        if let presentationEntity = entity.$presentation.value, presentationEntity?.isTBA != true {
             presentation = PresentationTransformerV2.transform(presentationEntity)
         } else {
             presentation = nil

--- a/Sources/App/Features/Sponsors/Controllers/SponsorAPIController.swift
+++ b/Sources/App/Features/Sponsors/Controllers/SponsorAPIController.swift
@@ -115,7 +115,11 @@ struct SponsorAPIController: RouteCollection {
     }
 
     private func onGet(request: Request) async throws -> Response {
-        let allSponsors = try await Sponsor.query(on: request.db).all()
+        let allSponsors = try await Sponsor.query(on: request.db)
+            .with(\.$event)
+            .all()
+            .filter { $0.event.isCurrent }
+        
         return try await GenericResponse(
             data: allSponsors.compactMap(SponsorTransformer.transform(_:))
         ).encodeResponse(for: request)

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -9,12 +9,26 @@ func routes(_ app: Application) throws {
  
     route.get { req -> View in
         do {
-            let speakers = try await Speaker.query(on: req.db).with(\.$presentations).all()
+            let speakers = try await Speaker
+                .query(on: req.db)
+                .with(\.$presentations) {
+                    $0.with(\.$event)
+                }
+                .all()
+                .filter {
+                    // filter speakers to only return those that have a presentation in the current event and where that
+                    // presentation has been announced
+                    $0.presentations.contains(where: { $0.event.isCurrent && $0.isTBA == false })
+                }
             
             // There might be a better way to handle this, but Leaf templates don't
             // support dictionaries holding arrays,
             // e.g [.gold: [sponsor, sponsor], .platinum: [sponsor, sponsor]]
-            let sponsorQuery = try await Sponsor.query(on: req.db).all()
+            let sponsorQuery = try await Sponsor.query(on: req.db)
+                .with(\.$event)
+                .all()
+                .filter { $0.event.isCurrent }
+            
             let platinumSponsors = sponsorQuery.filter { $0.sponsorLevel == .platinum }
             let silverSponsors = sponsorQuery.filter { $0.sponsorLevel == .silver }
             let goldSponsors = sponsorQuery.filter { $0.sponsorLevel == .gold }
@@ -26,14 +40,15 @@ func routes(_ app: Application) throws {
                         .with(\.$speaker)
                         .with(\.$secondSpeaker)
                 }
+                .with(\.$event)
                 .sort(\.$startDate)
                 .all()
+                .filter { $0.event.isCurrent }
             
             return try await req.view.render("Home/home", HomeContext(
                 speakers: speakers,
                 cfpEnabled: cfpExpirationDate > Date(),
                 ticketsEnabled: false,
-                conferenceEnded: true,
                 slots: slots,
                 platinumSponsors: platinumSponsors,
                 silverSponsors: silverSponsors,


### PR DESCRIPTION
This allows us to hide all speakers, sponsors, and presentations from a previous event from both the mobile app and the website simply by marking the event as "not current".

Merging this will cause the API to return empty arrays for the schedule and sponsors list (as there are non defined for this year yet).