### PR TITLE
Return all events with schedule API call

### DIFF
--- a/Sources/App/Features/Schedule/Models/ScheduleResponse+V2.swift
+++ b/Sources/App/Features/Schedule/Models/ScheduleResponse+V2.swift
@@ -3,5 +3,6 @@ import Vapor
 
 struct ScheduleResponseV2: Content {
     let event: EventResponse
+    let events: [EventResponse]
     let slots: [SlotResponseV2]
 }

--- a/Sources/App/Features/Schedule/Transformer/ScheduleTransformer+V2.swift
+++ b/Sources/App/Features/Schedule/Transformer/ScheduleTransformer+V2.swift
@@ -2,11 +2,14 @@ import Foundation
 
 // A unique transformer as it doesn't actually represent an entity
 enum ScheduleTransformerV2 {
-    static func transform(event: Event, slots: [Slot]) -> ScheduleResponseV2? {
+    static func transform(event: Event, events: [Event], slots: [Slot]) -> ScheduleResponseV2? {
         guard let eventResponse = EventTransformer.transform(event) else { return nil }
+
+        let eventsResponse = events.compactMap { EventTransformer.transform($0)}
 
         return ScheduleResponseV2(
             event: eventResponse,
+            events: eventsResponse,
             slots: slots.compactMap(SlotTransformerV2.transform(_:)).sorted(by: {
                 if let firstDate = $0.date, let secondDate = $1.date {
                     return firstDate < secondDate


### PR DESCRIPTION
Add a new array of events with the schedule API call.  
This will be used within the App to enable linking to previous events.  