### PR TITLE
Update CFP URL

### DIFF
--- a/Sources/App/Features/Home/HomeRouteController.swift
+++ b/Sources/App/Features/Home/HomeRouteController.swift
@@ -48,7 +48,7 @@ struct HomeRouteController: RouteCollection {
     
     func cfp(req: Request) async throws -> View {
         let context = try await getContext(req: req)
-        let sessionize = try await SessionizeService().loadEvent(slug: "swiftleeds-ios-conference-in-leeds-c", req: req)
+        let sessionize = try await SessionizeService().loadEvent(slug: "swiftleeds-ios-conference-in-leeds", req: req)
         
         let stage = CfpContext.Stage(
             now: Date(),


### PR DESCRIPTION
https://twitter.com/___freddi___/status/1749473814734602514

Not sure what caused the Sessionize URL to change but it breaks the site 😅 

```
curl "https://sessionize.com/api/universal/event?slug=swiftleeds-ios-conference-in-leeds" \
  -X GET \
  -H "X-API-KEY: redacted"
```

Have tested this cURL command and it works - but not tested this PR (wrong laptop).