### PR TITLE
Only run GitHub actions if repo owner is `SwiftLeeds`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   deploy:
+    if: github.repository_owner == 'SwiftLeeds'
     runs-on: ubuntu-latest
     needs: build
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,11 @@
 name: Build SwiftLeeds
 
 on:
-  pull_request_target:
+  pull_request:
   push:
     branches: [main]
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
@@ -48,9 +48,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Authenticate with Google Cloud
-        uses: 'google-github-actions/auth@v2'
+        uses: "google-github-actions/auth@v2"
         with:
-          credentials_json: '${{ secrets.GAR_JSON_KEY }}'
+          credentials_json: "${{ secrets.GAR_JSON_KEY }}"
 
       - name: Create GitHub Deployment
         uses: bobheadxi/deployments@v1
@@ -67,7 +67,7 @@ jobs:
           service: swiftleeds-web-${{ github.head_ref || github.ref_name }}
           region: europe-west2
           image: europe-west2-docker.pkg.dev/swiftleeds-website/swiftleeds-web/web:${{ github.head_ref || github.ref_name }}-latest
-          flags: '--allow-unauthenticated'
+          flags: "--allow-unauthenticated"
           env_vars: |
             BUCKET_NAME_PRESENTATIONS=swiftleeds-presentations
             BUCKET_NAME_SPEAKERS=swiftleeds-speakers

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
+          push: ${{ github.event_name == 'push' }} # Only push to PRD if the event is an push event
           provenance: false
           tags: europe-west2-docker.pkg.dev/swiftleeds-website/swiftleeds-web/web:${{ github.head_ref || github.ref_name }}-latest
           cache-from: type=gha

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository_owner == 'SwiftLeeds'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Google Artifact Registry
+        if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           registry: europe-west2-docker.pkg.dev
@@ -48,6 +49,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Authenticate with Google Cloud
+        if: github.event_name == 'push'
         uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.GAR_JSON_KEY }}'
@@ -61,6 +63,7 @@ jobs:
           ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Deploy to Cloud Run
+        if: github.event_name == 'push'
         id: deploy
         uses: google-github-actions/deploy-cloudrun@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build SwiftLeeds
 
 on:
-  pull_request:
+  pull_request_target:
   push:
     branches: [main]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Google Artifact Registry
-        if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           registry: europe-west2-docker.pkg.dev
@@ -33,7 +32,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: ${{ github.event_name == 'push' }} # Only push to PRD if the event is an push event
+          push: true
           provenance: false
           tags: europe-west2-docker.pkg.dev/swiftleeds-website/swiftleeds-web/web:${{ github.head_ref || github.ref_name }}-latest
           cache-from: type=gha
@@ -49,7 +48,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Authenticate with Google Cloud
-        if: github.event_name == 'push'
         uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.GAR_JSON_KEY }}'
@@ -63,7 +61,6 @@ jobs:
           ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Deploy to Cloud Run
-        if: github.event_name == 'push'
         id: deploy
         uses: google-github-actions/deploy-cloudrun@v2
         with:

--- a/.github/workflows/close.yml
+++ b/.github/workflows/close.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   destroy:
+    if: github.repository_owner == 'SwiftLeeds'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/close.yml
+++ b/.github/workflows/close.yml
@@ -1,8 +1,8 @@
 name: Destroy SwiftLeeds
 
 on:
-  pull_request_target:
-    types: [ closed ]
+  pull_request:
+    types: [closed]
 
 jobs:
   destroy:
@@ -11,12 +11,12 @@ jobs:
 
     steps:
       - name: Authenticate with Google Cloud
-        uses: 'google-github-actions/auth@v2'
+        uses: "google-github-actions/auth@v2"
         with:
-          credentials_json: '${{ secrets.GAR_JSON_KEY }}'
+          credentials_json: "${{ secrets.GAR_JSON_KEY }}"
 
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v2'
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v2"
 
       - name: Destroy Google Cloud Run Servce
         run: gcloud run services delete --quiet --region europe-west2 swiftleeds-web-${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/close.yml
+++ b/.github/workflows/close.yml
@@ -1,7 +1,7 @@
 name: Destroy SwiftLeeds
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ closed ]
 
 jobs:


### PR DESCRIPTION
Only run GitHub actions if repo owner is `SwiftLeeds`.
This prevent workflow failures (as shown below) in forked repos.

![image](https://github.com/SwiftLeeds/swiftleeds-web/assets/1290461/bd1c8ff0-8310-4d8e-add2-a7e8169faf47)
