### PR TITLE
Drop-in Sessions v2

### DIFF
--- a/Resources/Views/Dropin/slots.leaf
+++ b/Resources/Views/Dropin/slots.leaf
@@ -30,6 +30,10 @@
       </div>
     </div>
 
+    #if(session.capacity > 1):
+    <div class="alert alert-secondary" role="alert">This is a group session. Each session may have up to #(session.capacity) participants.</div>
+    #endif
+    
     #if(prompt):
     <div class="alert alert-secondary" role="alert">#(prompt)</div>
     #endif
@@ -45,13 +49,29 @@
               <h5 class="mb-1">#date(slot.date, "HH:mm")</h5>
             </div>
 
-            #if(slot.isOwner):
-            <small>This slot is your session!</small>
-            #elseif(slot.owner):
-            <small class="text-danger">This slot is taken by #(slot.owner).</small>
+            #if(session.capacity > 1):
+            
+                #if(slot.isOwner):
+                <small>You are booked on this session with #(count(slot.owners) - 1) others.</small>
+                #elseif(count(slot.owners) == session.capacity):
+                <small class="text-danger">This session is full.</small>
+                #else:
+                <small>This session is bookable, it currently has #count(slot.owners) participants.</small>
+                #endif
+            
             #else:
-            <small>This slot is available.</small>
+            
+                #if(slot.isOwner):
+                <small>This slot is your session!</small>
+                #elseif(count(slot.owners) == 0):
+                <small>This slot is available.</small>
+                #else:
+                <small class="text-danger">This slot is taken by #for(owner in slot.owners):#(owner)#endfor.</small>
+                #endif
+            
             #endif
+            
+            
           </button>
 
           #if(slot.isOwner):

--- a/Sources/App/Features/DropIns/Controllers/DropInRouteController.swift
+++ b/Sources/App/Features/DropIns/Controllers/DropInRouteController.swift
@@ -36,7 +36,7 @@ struct DropInRouteController: RouteCollection {
             return DropInSessionSlotsContext.Slot(
                 id: id,
                 date: $0.date,
-                owner: $0.ticketOwner,
+                owners: $0.ticketOwner,
                 isOwner: false
             )
         }.sorted(by: { $0.date < $1.date }) // sort times so they're in order on the day

--- a/Sources/App/Features/DropIns/Controllers/DropInUserRouteController.swift
+++ b/Sources/App/Features/DropIns/Controllers/DropInUserRouteController.swift
@@ -6,7 +6,7 @@ struct DropInUserRouteController: RouteCollection {
         routes.grouped(ValidTicketMiddleware()).group("drop-in") { builder in
             // list available sessions
             builder.get { req async throws -> View in
-                guard let currentEvent = try await Event.query(on: req.db).filter(\.$isCurrent == true).first() else {
+                guard let currentEvent = req.storage.get(CurrentEventKey.self) else {
                     throw Abort(.badRequest, reason: "unable to identify current event")
                 }
                 

--- a/Sources/App/Features/DropIns/Controllers/DropInUserRouteController.swift
+++ b/Sources/App/Features/DropIns/Controllers/DropInUserRouteController.swift
@@ -210,6 +210,7 @@ struct DropInSessionViewModel: Codable {
     let ownerImageUrl: String?
     let ownerLink: String?
     let availability: String
+    let capacity: Int
     
     init(model: DropInSession) {
         self.id = model.id?.uuidString ?? ""
@@ -219,8 +220,9 @@ struct DropInSessionViewModel: Codable {
         self.ownerImageUrl = model.ownerImageUrl
         self.ownerLink = model.ownerLink
         self.availability = Self.generateAvailabilityString(
-            slotCount: model.slots.filter { $0.ticket == nil }.count
+            slotCount: model.slots.filter { $0.ticket.count < model.maxTicketsPerSlot }.count
         )
+        self.capacity = model.maxTicketsPerSlot
     }
     
     static func generateAvailabilityString(slotCount: Int) -> String {

--- a/Sources/App/Features/DropIns/Controllers/DropInUserRouteController.swift
+++ b/Sources/App/Features/DropIns/Controllers/DropInUserRouteController.swift
@@ -63,8 +63,8 @@ struct DropInUserRouteController: RouteCollection {
                     return DropInSessionSlotsContext.Slot(
                         id: id,
                         date: $0.date,
-                        owner: $0.ticketOwner,
-                        isOwner: $0.ticket == ticket.slug
+                        owners: $0.ticketOwner,
+                        isOwner: $0.ticket.contains(ticket.slug)
                     )
                 }.sorted(by: { $0.date < $1.date }) // sort times so they're in order on the day
                 
@@ -107,7 +107,7 @@ struct DropInUserRouteController: RouteCollection {
                     return req.redirect(to: "/drop-in/\(sessionID)")
                 }
                 
-                guard slot.ticket == ticket.slug else {
+                guard slot.ticket.contains(ticket.slug) else {
                     // it's not their ticket!
                     let message = "This is not your ticket to cancel."
                         .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
@@ -115,9 +115,9 @@ struct DropInUserRouteController: RouteCollection {
                     return req.redirect(to: "/drop-in/\(sessionID)?prompt=\(message ?? "")")
                 }
                 
-                // clear our ticket
-                slot.ticket = nil
-                slot.ticketOwner = nil
+                // clear out ticket
+                slot.ticket.removeAll(where: { $0 == ticket.slug })
+                slot.ticketOwner.removeAll(where: { $0 == ticket.fullName })
                 try await slot.save(on: req.db)
                 
                 let message = "Session cancelled, you may book another slot now."
@@ -153,31 +153,38 @@ struct DropInUserRouteController: RouteCollection {
                     return req.redirect(to: "/drop-in/\(sessionID)")
                 }
                 
-                guard slot.ticket == nil else {
-                    // ticket is already taken!
-                    let message = "This session has already been taken."
-                        .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
-                    
-                    return req.redirect(to: "/drop-in/\(sessionID)?prompt=\(message ?? "")")
+                if slot.ticket.count >= slot.session.maxTicketsPerSlot {
+                    // ticket are all taken!
+                    if slot.session.maxTicketsPerSlot == 1 {
+                        let message = "This session has already been taken."
+                            .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+                        
+                        return req.redirect(to: "/drop-in/\(sessionID)?prompt=\(message ?? "")")
+                    } else {
+                        let message = "This session is already full."
+                            .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+                        
+                        return req.redirect(to: "/drop-in/\(sessionID)?prompt=\(message ?? "")")
+                    }
                 }
                 
                 let existingSlots: [DropInSessionSlot] = try await DropInSessionSlot
                     .query(on: req.db)
-                    .filter(\.$ticket == ticket.slug)
                     .with(\.$session)
                     .all()
                 
-                if existingSlots.contains(where: { $0.session.exclusivityKey == slot.session.exclusivityKey }) {
-                    // they already have a slot booked
+                if existingSlots.filter({ $0.ticket.contains(ticket.slug) })
+                                .contains(where: { $0.session.exclusivityKey == slot.session.exclusivityKey }) {
+                    // they already have a slot booked with same exclusivity key
                     let message = "You already have a session of this type booked, please cancel it first before booking another."
                         .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
                     
                     return req.redirect(to: "/drop-in/\(sessionID)?prompt=\(message ?? "")")
                 }
                 
-                // update ticket owner
-                slot.ticket = ticket.slug
-                slot.ticketOwner = ticket.first_name + " " + ticket.last_name
+                // append ticket owner
+                slot.ticket.append(ticket.slug)
+                slot.ticketOwner.append(ticket.fullName)
                 try await slot.save(on: req.db)
                 
                 let message = "Session booked, see you in Leeds!"
@@ -237,7 +244,7 @@ struct DropInSessionSlotsContext: Content {
     struct Slot: Codable {
         let id: String
         let date: Date
-        let owner: String?
+        let owners: [String]
         let isOwner: Bool
     }
     

--- a/Sources/App/Features/DropIns/Models/DropInSession.swift
+++ b/Sources/App/Features/DropIns/Models/DropInSession.swift
@@ -18,6 +18,15 @@ final class DropInSession: Model, Content {
     @Field(key: "description")
     var description: String
     
+    // The total number of people who can have a ticket for a single slot
+    @Field(key: "max_tickets")
+    var maxTicketsPerSlot: Int
+    
+    // The total number of tickets a single attendee can have (one per key)
+    @Field(key: "exclusivity_key")
+    var exclusivityKey: String
+    
+    // Owner presents the individual who is running the drop-in session
     @Field(key: "owner")
     var owner: String
     
@@ -26,6 +35,16 @@ final class DropInSession: Model, Content {
     
     @Field(key: "owner_link")
     var ownerLink: String?
+    
+    // Company is for drop-in sessions which relate to a branded product (it may or may not be sponsored)
+    @Field(key: "company")
+    var company: String?
+    
+    @Field(key: "company_image_url")
+    var companyrImageUrl: String?
+    
+    @Field(key: "company_link")
+    var companyLink: String?
     
     @Parent(key: "event_id")
     public var event: Event

--- a/Sources/App/Features/DropIns/Models/DropInSession.swift
+++ b/Sources/App/Features/DropIns/Models/DropInSession.swift
@@ -41,7 +41,7 @@ final class DropInSession: Model, Content {
     var company: String?
     
     @Field(key: "company_image_url")
-    var companyrImageUrl: String?
+    var companyImageUrl: String?
     
     @Field(key: "company_link")
     var companyLink: String?

--- a/Sources/App/Features/DropIns/Models/DropInSessionSlot.swift
+++ b/Sources/App/Features/DropIns/Models/DropInSessionSlot.swift
@@ -16,10 +16,10 @@ final class DropInSessionSlot: Model, Content {
     var date: Date
     
     @Field(key: "ticket")
-    var ticket: String?
+    var ticket: [String]
     
     @Field(key: "ticket_owner")
-    var ticketOwner: String?
+    var ticketOwner: [String]
     
     @Parent(key: "session_id")
     public var session: DropInSession

--- a/Sources/App/Features/DropIns/Models/Migrations/AddDropInGroupsMigration.swift
+++ b/Sources/App/Features/DropIns/Models/Migrations/AddDropInGroupsMigration.swift
@@ -18,6 +18,6 @@ final class AddDropInGroupsMigration: AsyncMigration {
             .deleteField("company")
             .deleteField("company_image_url")
             .deleteField("company_link")
-            .delete()
+            .update()
     }
 }

--- a/Sources/App/Features/DropIns/Models/Migrations/AddDropInGroupsMigration.swift
+++ b/Sources/App/Features/DropIns/Models/Migrations/AddDropInGroupsMigration.swift
@@ -1,0 +1,23 @@
+import Fluent
+
+final class AddDropInGroupsMigration: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema(Schema.dropInSessions)
+            .field("max_tickets", .int, .sql(.default(1)), .required)
+            .field("exclusivity_key", .string, .sql(.default("A")), .required)
+            .field("company", .string)
+            .field("company_image_url", .string)
+            .field("company_link", .string)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema(Schema.dropInSessions)
+            .deleteField("max_tickets")
+            .deleteField("exclusivity_key")
+            .deleteField("company")
+            .deleteField("company_image_url")
+            .deleteField("company_link")
+            .delete()
+    }
+}

--- a/Sources/App/Features/DropIns/Models/Migrations/UseArrayDropInOwnerMigration.swift
+++ b/Sources/App/Features/DropIns/Models/Migrations/UseArrayDropInOwnerMigration.swift
@@ -1,0 +1,18 @@
+import Fluent
+
+final class UseArrayDropInOwnerMigration: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        // I'll be honest, I tried so many ways to get this to be a non-breaking change... but I couldn't get it to work
+        // So it's a destructive update and I've manually fixed production (James Sherlock - May 31st 2024)
+        try await database.schema(Schema.dropInSessionSlots)
+            .deleteField("ticket")
+            .deleteField("ticket_owner")
+            .field("ticket", .array(of: .string), .sql(.default("{}")), .required)
+            .field("ticket_owner", .array(of: .string), .sql(.default("{}")), .required)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        // This is a breaking change
+    }
+}

--- a/Sources/App/Features/DropIns/Models/Migrations/UseArrayDropInOwnerMigration.swift
+++ b/Sources/App/Features/DropIns/Models/Migrations/UseArrayDropInOwnerMigration.swift
@@ -13,6 +13,12 @@ final class UseArrayDropInOwnerMigration: AsyncMigration {
     }
 
     func revert(on database: Database) async throws {
-        // This is a breaking change
+        // Note, this is a destructive change and all data will be lost.
+        try await database.schema(Schema.dropInSessionSlots)
+            .deleteField("ticket")
+            .deleteField("ticket_owner")
+            .field("ticket", .string)
+            .field("ticket_owner", .string)
+            .update()
     }
 }

--- a/Sources/App/Features/Events/Models/Event.swift
+++ b/Sources/App/Features/Events/Models/Event.swift
@@ -22,6 +22,9 @@ final class Event: Model, Content {
     @Field(key: "is_current")
     var isCurrent: Bool
     
+    @Field(key: "tito_event")
+    var titoEvent: String?
+    
     @Children(for: \.$event)
     var presentations: [Presentation]
 

--- a/Sources/App/Features/Events/Models/Migrations/Event+Migration+V3.swift
+++ b/Sources/App/Features/Events/Models/Migrations/Event+Migration+V3.swift
@@ -1,0 +1,15 @@
+import Fluent
+
+final class EventMigrationV3: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema(Schema.event)
+            .field("tito_event", .string)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema(Schema.event)
+            .deleteField("tito_event")
+            .update()
+    }
+}

--- a/Sources/App/Features/Tickets/Models/TitoTicket.swift
+++ b/Sources/App/Features/Tickets/Models/TitoTicket.swift
@@ -16,6 +16,10 @@ struct TitoTicket: Codable {
     let avatar_url: URL?
     let responses: [String: String]
     let release: Release?
+    
+    var fullName: String {
+        first_name + " " + last_name
+    }
 }
 
 struct TitoResponse: Decodable {

--- a/Sources/App/Features/Tickets/Services/TitoService.swift
+++ b/Sources/App/Features/Tickets/Services/TitoService.swift
@@ -19,14 +19,12 @@ struct TitoService {
         let ticketOpt = ticketResponse.tickets.first(where: {
             // case insensitive comparisons
             $0.reference.lowercased() == payload.ticket.lowercased() &&
-            $0.email.lowercased() == payload.email.lowercased()
+            $0.email?.lowercased() == payload.email.lowercased() &&
+            // ensure unassigned tickets do not get captured here
+            $0.email != nil
         })
         
-        guard let ticket = ticketOpt else {
-            return nil
-        }
-        
-        return ticket
+        return ticketOpt
     }
     
     func ticket(stub: String, req: Request) async throws -> TitoTicket? {
@@ -78,7 +76,7 @@ struct TitoTicketsResponse: Decodable {
     struct Ticket: Decodable {
         let slug: String
         let reference: String
-        let email: String
+        let email: String?
     }
     
     struct Meta: Decodable {

--- a/Sources/App/Migrations.swift
+++ b/Sources/App/Migrations.swift
@@ -72,6 +72,8 @@ class Migrations {
 
         // Add Video URL to Presentations table
         app.migrations.add(PresentationMigrationV5())
+        
+        app.migrations.add(AddDropInGroupsMigration()) // Drop-ins v2 (Group Sessions)
 
         do {
             guard let url = Environment.get("DATABASE_URL") else {

--- a/Sources/App/Migrations.swift
+++ b/Sources/App/Migrations.swift
@@ -74,6 +74,7 @@ class Migrations {
         app.migrations.add(PresentationMigrationV5())
         
         app.migrations.add(AddDropInGroupsMigration()) // Drop-ins v2 (Group Sessions)
+        app.migrations.add(EventMigrationV3()) // Adds tito ID
 
         do {
             guard let url = Environment.get("DATABASE_URL") else {

--- a/Sources/App/Migrations.swift
+++ b/Sources/App/Migrations.swift
@@ -75,6 +75,7 @@ class Migrations {
         
         app.migrations.add(AddDropInGroupsMigration()) // Drop-ins v2 (Group Sessions)
         app.migrations.add(EventMigrationV3()) // Adds tito ID
+        app.migrations.add(UseArrayDropInOwnerMigration()) // Use arrays for slot owners
 
         do {
             guard let url = Environment.get("DATABASE_URL") else {


### PR DESCRIPTION
* Adds support for users joining more than one drop-in session (exclusivity groups)
* Adds support for sessions with more than one participant (group sessions)
* Adds database support (no UI changes) for brand associated sessions (not sponsored)
* Adds support for database-driven tito ticket lookup (basically just means no code changes next year, but could mean multi-year support too and unlocks other features down the line)
* Fixes a bug introduced by Tito where unassigned tickets were being returned and breaking lookup

I have validated this locally for all variations.