### PR TITLE
Move Session Driver

### DIFF
--- a/Sources/App/Migrations.swift
+++ b/Sources/App/Migrations.swift
@@ -4,8 +4,6 @@ import Vapor
 
 class Migrations {
     static func migrate(_ app: Application) throws {
-        app.sessions.use(.fluent(.psql))
-        
         // User Migrations
         app.migrations.add(UserMigrationV1())
         

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -4,6 +4,9 @@ import LeafMarkdown
 import Vapor
 
 public func configure(_ app: Application) throws {
+    // Sessions
+    app.sessions.use(.fluent(.psql))
+    
     // Middleware
     app.middleware.use(AppleAppSiteAssociationMiddleware())
     app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))


### PR DESCRIPTION
Per [documentation](https://docs.vapor.codes/advanced/sessions/), sessions.use must be used before setting middleware. We had it flipped the wrong way.