### PR TITLE
Remove Secret Manager (Use GitHub Secrets)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,18 +73,17 @@ jobs:
             BUCKET_NAME_SPEAKERS=swiftleeds-speakers
             S3_BUCKET_NAME=swiftleeds-speakers
             ENABLE_AASA=true
-          secrets: |
-            CHECKIN_SECRET=APP_CHECKIN_SECRET:latest
-            CHECKIN_TAG=TITO_CHECKIN_TAG:latest
-            DATABASE_URL=SUPABASE_DATABASE_URL:latest
-            P8_CERTIFICATE=APNS_CERTIFICATE:latest
-            S3_KEY=AWS_KEY:latest
-            S3_SECRET=AWS_SECRET:latest
-            SESSIONIZE_KEY=SESSIONIZE_KEY:latest
-            TITO_TOKEN=TITO_KEY:latest
-            FLICKR_KEY=FLICKR_KEY:latest
-            FLICKR_SECRET=FLICKR_SECRET:latest
-            REFUND_PERIOD=30
+            CHECKIN_SECRET=${{ secrets.CHECKIN_SECRET }}
+            CHECKIN_TAG=${{ secrets.CHECKIN_TAG }}
+            DATABASE_URL=${{ secrets.DATABASE_URL }}
+            P8_CERTIFICATE=${{ secrets.P8_CERTIFICATE }}
+            S3_KEY=${{ secrets.S3_KEY }}
+            S3_SECRET=${{ secrets.S3_SECRET }}
+            SESSIONIZE_KEY=${{ secrets.SESSIONIZE_KEY }}
+            TITO_TOKEN=${{ secrets.TITO_TOKEN }}
+            FLICKR_KEY=${{ secrets.FLICKR_KEY }}
+            FLICKR_SECRET=${{ secrets.FLICKR_SECRET }}
+            REFUND_PERIOD=${{ secrets.REFUND_PERIOD }}
 
       - name: Update GitHub Deployment
         uses: bobheadxi/deployments@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,7 @@ jobs:
             TITO_TOKEN=TITO_KEY:latest
             FLICKR_KEY=FLICKR_KEY:latest
             FLICKR_SECRET=FLICKR_SECRET:latest
+            REFUND_PERIOD=30
 
       - name: Update GitHub Deployment
         uses: bobheadxi/deployments@v1

--- a/.github/workflows/close.yml
+++ b/.github/workflows/close.yml
@@ -26,3 +26,6 @@ jobs:
         with:
           step: deactivate-env
           env: ${{ github.head_ref || github.ref_name }}
+
+      - name: Untag Container Image
+        run: gcloud container images untag --region europe-west2 swiftleeds-website/swiftleeds-web/web:${{ github.head_ref || github.ref_name }}-latest

--- a/Resources/Views/Hub/home.leaf
+++ b/Resources/Views/Hub/home.leaf
@@ -237,7 +237,7 @@
               
               <!-- Refund Ticket -->
               <h2 id="refund" class="h5 text-primary pt-1 pt-lg-3 mt-4">Ticket Refunds</h2>
-              <p>SwiftLeeds will always refund 100% of ticket purchases (minus our 3% processing fee) if requested more than 30&nbsp;days before the conference begins. This year, that deadline is #(refund.deadline).</p>
+              <p>SwiftLeeds will always refund 100% of ticket purchases (minus our 3% processing fee) if requested more than #(refund.days)&nbsp;days before the conference begins. This year, that deadline is #(refund.deadline).</p>
               
               #if(refund.active):
               <a href="#(refund.emailUrl)" target="_blank" class="btn btn-danger">Email us now</a>


### PR DESCRIPTION
Also untag artifacts on PR close, and configure images to auto-delete once untagged.

Looking at billing, this will be a 95% decrease in costs. Moving to GHCR would likely solve the rest, but seems insignificant so going to roll with this and review in a couple months.