### PR TITLE
Admin Panel Extras

### DIFF
--- a/Public/js/admin.js
+++ b/Public/js/admin.js
@@ -63,6 +63,24 @@ $("[data-swiftleeds-admin]").on('click', (e) => {
                 modal.find('.modal-dialog').addClass(dataSize.data('modal-size'));
             }
             
+            modal.find('[data-swiftleeds-form="delete"]').each((offset, element) => {
+                const popover = new bootstrap.Popover(element, {
+                    title: 'Are you sure?',
+                    content: 'This will permanently delete this item.',
+                    trigger: 'click',
+                    html: true,
+                    placement: 'top',
+                    container: modal,
+                    customClass: 'delete-confirmation'
+                });
+                
+                element.addEventListener('show.bs.popover', () => {
+                    setTimeout(() => {
+                        popover.hide();
+                    }, 2000);
+                })
+            });
+            
             $("[data-swiftleeds-selectcurrentevent]").each((offset, element) => {
                 const value = localStorage['selectedEvent'];
                 $(element).find('option[value=' + value + ']').attr('selected', true);
@@ -78,6 +96,14 @@ $("[data-swiftleeds-admin]").on('click', (e) => {
                     
                     const crudEvent = $(event.currentTarget).data('swiftleeds-form');
                     console.log('Received Form Event: ' + crudEvent);
+                        
+                    if(crudEvent == 'delete') {
+                        if ($('.popover.delete-confirmation').length == 0) {
+                            // If the popover is not visible, then do not continue.
+                            // This requires that you press the button twice to delete.
+                            return;
+                        }
+                    }
                     
                     const isValid = element.checkValidity();
                     element.classList.add('was-validated');

--- a/Public/js/admin.js
+++ b/Public/js/admin.js
@@ -57,6 +57,11 @@ $("[data-swiftleeds-admin]").on('click', (e) => {
         success: (data) => {
             modal.find('.modal-content').html(data);
             
+            $("[data-swiftleeds-selectcurrentevent]").each((offset, element) => {
+                const value = localStorage['selectedEvent'];
+                $(element).find('option[value=' + value + ']').attr('selected', true);
+            });
+            
             modal.find('.needs-validation').each((offset, element) => {
                 const form = $(element);
                 form.on('click', '[data-swiftleeds-form]', (event) => {
@@ -71,14 +76,18 @@ $("[data-swiftleeds-admin]").on('click', (e) => {
                         // POST admin/:key/:ID/update
                         // POST admin/:key/:ID/delete
                         const crudEndpoint = 'admin/' + trigger.data('swiftleeds-admin') + '/' + crudEvent;
+                        var disabled = form.find(':input:disabled').removeAttr('disabled');
                         const formData = new FormData(element);
                         const useFormData = form.attr('enctype') == 'multipart/form-data'
+                        const data = useFormData ? formData : form.serialize();
+                        disabled.attr('disabled','disabled');
+                        
                         console.log('Requesting ' + crudEndpoint);
                         
                         $.ajax({
                             type: "POST",
                             url: crudEndpoint,
-                            data: useFormData ? formData : form.serialize(),
+                            data: data,
                             contentType: useFormData ? false : 'application/x-www-form-urlencoded',
                             processData: !useFormData,
                             success: (data) => {

--- a/Resources/Views/Admin/Form/activity_form.leaf
+++ b/Resources/Views/Admin/Form/activity_form.leaf
@@ -5,9 +5,8 @@
 </div>
 <div class="modal-body">
         <div class="mb-3">
-            <label for="event" class="form-label">Event</label>
-            <select name="eventID" class="form-control" required>
-              <option selected disabled value="">Select an event</option>
+            <label for="event" class="form-label">#if(activity):Change#endif Event</label>
+            <select name="eventID" class="form-control" required #if(!activity):disabled#endif data-swiftleeds-selectCurrentEvent="true">
               #for(event in events):
                 <option #if(event.id == activity.event.id): selected #endif id="eventID" name="eventID" value=#(event.id)>
                   #(event.name)

--- a/Resources/Views/Admin/Form/dropin_form.leaf
+++ b/Resources/Views/Admin/Form/dropin_form.leaf
@@ -1,0 +1,95 @@
+<form class="needs-validation d-flex flex-column position-relative overflow-hidden" novalidate enctype="multipart/form-data">
+<div class="modal-header">
+    <h5 class="modal-title">#if(session):Edit Session#else:Create Session#endif</h5>
+    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+</div>
+<div class="modal-body">
+    <div class="mb-3">
+        <label for="event" class="form-label">#if(session):Change#endif Event</label>
+        <select name="eventID" class="form-control" required #if(!session):disabled#endif data-swiftleeds-selectCurrentEvent="true">
+          #for(event in events):
+            <option #if(event.id == session.event.id): selected #endif id="eventID" name="eventID" value=#(event.id)>
+              #(event.name)
+            </option>
+          #endfor
+        </select>
+    </div>
+        
+    <div class="mb-3">
+        <label for="title" class="form-label">Title</label>
+        <input class="form-control" id="title" name="title" value="#(session.title)" required>
+        <div class="invalid-feedback">Please enter a title.</div>
+    </div>
+    
+    <div class="mb-3">
+        <label for="description" class="form-label">Description</label>
+        <textarea class="form-control" name="description" id="description" rows="10" required>#(session.description)</textarea>
+        <div class="invalid-feedback">Please enter a description.</div>
+    </div>
+
+    <div class="mb-3">
+        <label for="ownerName" class="form-label">Owner</label>
+        <input class="form-control" type="text" id="ownerName" name="ownerName" value="#(session.owner)" placeholder="Adam Rush" required>
+        <div class="invalid-feedback">Please provide an owner name.</div>
+    </div>
+
+    <div class="mb-3">
+        <label for="ownerLink" class="form-label">Owner Link</label>
+        <input class="form-control" type="text" id="ownerLink" name="ownerLink" value="#(session.ownerLink)" placeholder="https://twitter.com/swift_leeds" required>
+        <div class="invalid-feedback">Please provide a Twitter URL.</div>
+    </div>
+    
+    <div class="mb-3">
+        <label for="ownerImage" class="form-label">Owner Image</label>
+        <input class="form-control" type="file" id="ownerImage" name="ownerImage">
+
+        #if(session.ownerImageUrl):
+        <p class="form-label mt-2">Existing image</p>
+        <img src="#awsImage(session.ownerImageUrl)" class="img-thumbnail" height="100px" style="height: 100px;">
+        #endif
+    </div>
+    
+    <div class="form-check form-switch">
+        <input type="checkbox" class="form-check-input" id="isPublic" name="isPublic" #if(session.isPublic):checked#endif>
+        <label class="form-check-label" for="isPublic">Is Public?</label>
+    </div>
+    
+    <div class="form-check form-switch">
+        <input type="checkbox" class="form-check-input" id="isBookable" name="isBookable" #if(session.maxTicketsPerSlot > 0):checked#endif>
+        <label class="form-check-label" for="isBookable">Is Bookable?</label>
+    </div>
+    
+    <div class="form-check form-switch">
+        <input type="checkbox" class="form-check-input" id="isGroup" name="isGroup" #if(session.maxTicketsPerSlot > 1):checked#endif>
+        <label class="form-check-label" for="isGroup">Is Group?</label>
+    </div>
+    
+    <div class="mb-3" id="groupSizeInput">
+        <label for="groupSize" class="form-label">Group Size</label>
+        <input class="form-control" type="number" id="groupSize" name="groupSize" #if(session.maxTicketsPerSlot):value="#(session.maxTicketsPerSlot)"#else:value="1"#endif min="0" max="100">
+    </div>
+    
+    <script>
+    function updateGroupSize(enabled) {
+        if (enabled) {
+            $("#groupSizeInput").show();
+        } else {
+            $("#groupSizeInput").hide();
+        }
+    }
+    
+    updateGroupSize(#if(session.maxTicketsPerSlot > 1):true#else:false#endif);
+    $("#isGroup").on('change', (event) => {
+        updateGroupSize($(event.currentTarget).prop("checked") == true);
+    });
+    </script>
+</div>
+<div class="modal-footer">
+    #if(session):
+    <button type="button" class="btn btn-danger btn-sm" data-swiftleeds-form="delete">Delete session</button>
+    <button type="button" class="btn btn-success btn-sm" data-swiftleeds-form="update">Save changes</button>
+    #else:
+    <button type="button" class="btn btn-success btn-sm" data-swiftleeds-form="create">Create session</button>
+    #endif
+</div>
+</form>

--- a/Resources/Views/Admin/Form/dropin_slot_form.leaf
+++ b/Resources/Views/Admin/Form/dropin_slot_form.leaf
@@ -1,0 +1,37 @@
+<div id="template" class="hidden">
+    #extend("Admin/Form/dropin_slot_form_row")
+</div>
+
+<form class="needs-validation d-flex flex-column position-relative overflow-hidden" novalidate>
+<div class="modal-header">
+    <h5 class="modal-title">Edit Session Slots</h5>
+    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+</div>
+<div class="modal-body">
+    <div id="container">
+        #for(slot in slots):
+            #extend("Admin/Form/dropin_slot_form_row")
+        #endfor
+    </div>
+    
+    <button type="button" class="btn btn-outline-secondary px-3 px-sm-4 addTemplate">
+        <i class="bx bx-plus fs-xl ms-sm-n1 me-sm-1"></i>
+        <span class="d-none d-sm-inline">Add Slot</span>
+    </button>
+    
+    <script>
+        if($("#container").html().trim() == "") {
+            $("#container").html($("#template").html());
+        }
+        $(".addTemplate").on('click', () => {
+            $("#container").append($("#template").html());
+        });
+        $("#container").on('click', '.removeTemplate', (e) => {
+            $(e.currentTarget).closest('.templateParent').remove();
+        });
+    </script>
+</div>
+<div class="modal-footer">
+    <button type="button" class="btn btn-success" data-swiftleeds-form="update">Update slots</button>
+</div>
+</form>

--- a/Resources/Views/Admin/Form/dropin_slot_form_row.leaf
+++ b/Resources/Views/Admin/Form/dropin_slot_form_row.leaf
@@ -1,0 +1,28 @@
+<div class="mb-3 templateParent">
+    <input type="hidden" value="#(slot.id)" name="ids[]">
+    <div class="input-group">
+    
+        <input
+            class="form-control"
+            type="datetime-local"
+            name="time[]"
+            min="#dateFix(session.event.date)"
+            max="#dateFix(session.event.date + 172800)"
+            value="#if(slot):#dateFix(slot.date)#else:#dateFix(session.event.date + 36000)#endif"
+            required
+        >
+        <input
+            class="form-control"
+            type="number"
+            name="duration[]"
+            value="#if(slot):#(slot.duration)#else:15#endif"
+            min="15"
+            max="180"
+            required
+        >
+        
+        <button type="button" class="btn btn-icon btn-lg #if(slot):btn-outline-danger#else:btn-outline-success#endif removeTemplate">
+            <i class="bx bx-x fs-xl"></i>
+        </button>
+    </div>
+</div>

--- a/Resources/Views/Admin/Form/event_form.leaf
+++ b/Resources/Views/Admin/Form/event_form.leaf
@@ -21,6 +21,11 @@
         <input class="form-control" type="text" id="location" name="location" value="#(event.location)" placeholder="The Playhouse, Leeds" required>
         <div class="invalid-feedback">Please provide a location.</div>
     </div>
+    
+    <div class="form-check form-switch">
+        <input type="checkbox" class="form-check-input" id="showSchedule" name="showSchedule" #if(event.showSchedule):checked#endif>
+        <label class="form-check-label" for="showSchedule">Show schedule?</label>
+    </div>
 
     <div class="form-check form-switch">
         <input type="checkbox" class="form-check-input" id="isCurrent" name="isCurrent" #if(event.isCurrent):checked disabled#endif>

--- a/Resources/Views/Admin/Form/presentation_form.leaf
+++ b/Resources/Views/Admin/Form/presentation_form.leaf
@@ -4,66 +4,65 @@
     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
 </div>
 <div class="modal-body">
-        <label for="event" class="form-label">Event</label>
-        <select name="eventID" class="form-control" required>
-          <option selected disabled value="">-- select an event --</option>
-          #for(event in events):
-            <option #if(event.id == presentation.event.id): selected #endif id="eventID" name="eventID" value=#(event.id)>
-              #(event.name)
-            </option>
-          #endfor
-        </select>
-        <div class="invalid-feedback">
-          Please select an event
+        <div class="mb-3">
+            <label for="event" class="form-label">#if(presentation):Change#endif Event</label>
+            <select name="eventID" class="form-control" required #if(!presentation):disabled#endif data-swiftleeds-selectCurrentEvent="true">
+              #for(event in events):
+                <option #if(event.id == presentation.event.id): selected #endif id="eventID" name="eventID" value=#(event.id)>
+                  #(event.name)
+                </option>
+              #endfor
+            </select>
+            <div class="invalid-feedback">Please select an event</div>
         </div>
-        <br>
 
         <div class="mb-3">
           <label for="title" class="form-label">Title</label>
           <input value="#(presentation.title)" class="form-control" name="title" id="title" required>
-          <div class="invalid-feedback">
-            Please enter a title
-          </div>
+          <div class="invalid-feedback">Please enter a title</div>
         </div>
 
         <div class="mb-3">
           <label for="synopsis" class="form-label">Synopsis</label>
           <textarea class="form-control" name="synopsis" id="synopsis" rows="10" required>#(presentation.synopsis)</textarea>
-          <div class="invalid-feedback">
-            Please enter a synopsis
-          </div>
-          <p>* Supports Markdown</p>
+          <div class="invalid-feedback">Please enter a synopsis</div>
         </div>
 
-        <label for="speakerID" class="form-label">Speaker</label>
-        <select name="speakerID" id="speakerID" class="form-control" required>
-          <option selected disabled value="">-- select a speaker --</option>
-          #for(speaker in speakers):
-            <option #if(speaker.id == presentation.speaker.id): selected #endif value=#(speaker.id)>
-              #(speaker.name)
-            </option>
-          #endfor
-        </select>
-        <div class="invalid-feedback">
-          Please select a speaker
+        <div class="mb-3">
+            <label for="speakerID" class="form-label">Speaker</label>
+            <select name="speakerID" id="speakerID" class="form-control" required>
+              <option selected disabled value="">-- select a speaker --</option>
+              #for(speaker in speakers):
+                <option #if(speaker.id == presentation.speaker.id): selected #endif value=#(speaker.id)>
+                  #(speaker.name)
+                </option>
+              #endfor
+            </select>
+            <div class="invalid-feedback">Please select a speaker</div>
         </div>
-        <br/>
-
-        <div class="form-group form-check">
-          <input type="checkbox" class="form-check-input" id="enableSecondSpeaker" data-toggle="toggle" checked="checked">
-          <label class="form-check-label" for="enableSecondSpeaker">Additional Speaker</label>
+        
+        <div class="form-check form-switch mb-3">
+          <input type="checkbox" class="form-check-input" id="enableSecondSpeaker" checked="checked">
+          <label class="form-check-label" for="enableSecondSpeaker">Has second speaker?</label>
         </div>
-
-        <select id="secondSpeakerSelect" name="secondSpeakerID" class="form-control secondSpeaker">
-          <option selected disabled value="">-- select additional speaker --</option>
-          #for(speaker in speakers):
-            <option #if(speaker.id == presentation.secondSpeaker.id): selected #endif value=#(speaker.id)>
-              #(speaker.name)
-            </option>
-          #endfor
-        </select>
-        <br>
-
+        
+        <div class="mb-3" id="secondSpeakerSelect">
+            <select name="secondSpeakerID" class="form-control secondSpeaker">
+            <option selected disabled value="">Select Second Speaker</option>
+              #for(speaker in speakers):
+                <option #if(speaker.id == presentation.secondSpeaker.id): selected #endif value=#(speaker.id)>
+                  #(speaker.name)
+                </option>
+              #endfor
+            </select>
+        </div>
+        
+        #if(presentation):
+        <div class="form-check form-switch mb-3">
+            <input type="checkbox" class="form-check-input" id="isAnnounced" name="isAnnounced" #if(!presentation.isTBA):checked#endif>
+            <label class="form-check-label" for="isAnnounced">Has been announced?</label>
+        </div>
+        
         <div class="mb-3">
           <label for="slidoURL" class="form-label">Slido URL</label>
           <input name="slidoURL" id="slidoURL" class="form-control" value="#(presentation.slidoURL)">
@@ -73,6 +72,7 @@
           <label for="videoURL" class="form-label">Video URL</label>
           <input name="videoURL" id="videoURL" class="form-control" value="#(presentation.videoURL)">
         </div>
+        #endif
         
     <script>
       function updateForSecondSpeaker(enabled) {

--- a/Resources/Views/Admin/Form/slot_form.leaf
+++ b/Resources/Views/Admin/Form/slot_form.leaf
@@ -5,9 +5,8 @@
 </div>
 <div class="modal-body">
         <div class="mb-3">
-            <label for="event" class="form-label">Event</label>
-            <select name="eventID" id="event" class="form-control" required>
-              <option selected disabled value="">-- select an event --</option>
+            <label for="event" class="form-label">#if(slot):Change#endif Event</label>
+            <select name="eventID" id="event" class="form-control" required #if(!slot):disabled#endif data-swiftleeds-selectCurrentEvent="true">
               #for(event in events):
                 <option #if(event.id == slot.event.id): selected #endif id="eventID" name="eventID" value=#(event.id)>
                   #(event.name)

--- a/Resources/Views/Admin/Form/sponsor_form.leaf
+++ b/Resources/Views/Admin/Form/sponsor_form.leaf
@@ -6,9 +6,8 @@
 <div class="modal-body">
 
         <div class="mb-3">
-            <label for="event" class="form-label">Event</label>
-            <select name="eventID" class="form-control" required>
-              <option selected disabled value="">Select an Event</option>
+            <label for="event" class="form-label">#if(sponsor):Change#endif Event</label>
+            <select name="eventID" class="form-control" required #if(!sponsor):disabled#endif data-swiftleeds-selectCurrentEvent="true">
               #for(event in events):
                 <option #if(event.id == sponsor.event.id): selected #endif id="eventID" name="eventID" value=#(event.id)>
                   #(event.name)

--- a/Resources/Views/Admin/dropins.leaf
+++ b/Resources/Views/Admin/dropins.leaf
@@ -14,13 +14,14 @@
       <div class="d-flex align-items-start me-3">
         <div>
           <div class="fw-medium text-nav mb-1">#(dropInSession.title)</div>
-          <span class="d-inline-block fs-sm text-muted pe-2 me-2">#(dropInSession.owner)</span>
+          <span class="d-inline-block fs-sm text-muted border-end pe-2 me-2">#(dropInSession.owner)</span>
+          <span class="d-inline-block fs-sm text-muted">#count(dropInSession.slots) slots</span>
         </div>
       </div>
       <div>
           <button data-swiftleeds-admin="dropins/slots/#(dropInSession.id)" class="btn btn-icon btn-outline-secondary me-2">
             <i class="bx bx-calendar fs-xl"></i>
-          </a>
+          </button>
           <button data-swiftleeds-admin="dropins/#(dropInSession.id)" class="btn btn-outline-secondary px-3 px-sm-4 me-2">
             <i class="bx bx-pencil fs-xl ms-sm-n1 me-sm-1"></i>
             <span class="d-none d-sm-inline">Edit</span>

--- a/Resources/Views/Admin/dropins.leaf
+++ b/Resources/Views/Admin/dropins.leaf
@@ -1,7 +1,7 @@
 <div class="d-flex align-items-center justify-content-between pt-xl-1 mb-3 pb-3">
     <h1 class="h2 mb-0">Drop-In Sessions</h1>
     
-    <button data-swiftleeds-admin="dropins" class="btn btn-outline-secondary px-3 px-sm-4" disabled>
+    <button data-swiftleeds-admin="dropins" class="btn btn-outline-secondary px-3 px-sm-4">
         <i class="bx bx-plus fs-xl me-sm-1"></i>
         <span class="d-none d-sm-inline">Add Session</span>
     </button>
@@ -17,10 +17,18 @@
           <span class="d-inline-block fs-sm text-muted pe-2 me-2">#(dropInSession.owner)</span>
         </div>
       </div>
-      <a href="/admin/dropins/print/#(dropInSession.id)" class="btn btn-outline-secondary px-3 px-sm-4">
-        <i class="bx bx-printer fs-xl ms-sm-n1 me-sm-1"></i>
-        <span class="d-none d-sm-inline">Print</span>
-      </a>
+      <div>
+          <button data-swiftleeds-admin="dropins/slots/#(dropInSession.id)" class="btn btn-icon btn-outline-secondary me-2">
+            <i class="bx bx-calendar fs-xl"></i>
+          </a>
+          <button data-swiftleeds-admin="dropins/#(dropInSession.id)" class="btn btn-outline-secondary px-3 px-sm-4 me-2">
+            <i class="bx bx-pencil fs-xl ms-sm-n1 me-sm-1"></i>
+            <span class="d-none d-sm-inline">Edit</span>
+          </button>
+          <a href="/admin/dropins/print/#(dropInSession.id)" target="_blank" class="btn btn-icon btn-outline-secondary">
+            <i class="bx bx-printer fs-xl"></i>
+          </a>
+      </div>
     </li>
     #endfor
 </ul>

--- a/Resources/Views/Admin/presentations.leaf
+++ b/Resources/Views/Admin/presentations.leaf
@@ -2,7 +2,7 @@
     <h1 class="h2 mb-0">Presentations</h1>
     
     <div>
-        <button data-swiftleeds-admin="presentations" class="btn btn-outline-info px-3 px-sm-4 me-2 disabled">
+        <button data-swiftleeds-admin="sessionize/modal/[FILTER_EVENT]" class="btn btn-outline-info px-3 px-sm-4 me-2">
             <i class="bx bx-sync fs-xl me-sm-1"></i>
             <span class="d-none d-sm-inline">Sync with Sessionize</span>
         </button>

--- a/Resources/Views/Admin/speakers.leaf
+++ b/Resources/Views/Admin/speakers.leaf
@@ -1,17 +1,10 @@
 <div class="d-flex align-items-center justify-content-between pt-xl-1 mb-3 pb-3">
     <h1 class="h2 mb-0">Speakers</h1>
     
-    <div>
-        <button data-swiftleeds-admin="speakers" class="btn btn-outline-info px-3 px-sm-4 me-2 disabled">
-            <i class="bx bx-sync fs-xl me-sm-1"></i>
-            <span class="d-none d-sm-inline">Sync with Sessionize</span>
-        </button>
-        
-        <button data-swiftleeds-admin="speakers" class="btn btn-outline-secondary px-3 px-sm-4">
-            <i class="bx bx-plus fs-xl me-sm-1"></i>
-            <span class="d-none d-sm-inline">Add Speaker</span>
-        </button>
-    </div>
+    <button data-swiftleeds-admin="speakers" class="btn btn-outline-secondary px-3 px-sm-4">
+        <i class="bx bx-plus fs-xl me-sm-1"></i>
+        <span class="d-none d-sm-inline">Add Speaker</span>
+    </button>
 </div>
 
 <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-3 g-4">

--- a/Resources/Views/Admin/sync_modal.leaf
+++ b/Resources/Views/Admin/sync_modal.leaf
@@ -1,0 +1,71 @@
+<form class="needs-validation d-flex flex-column position-relative overflow-hidden" novalidate #if(count(changes) > 0):data-modal-size="modal-xl"#endif>
+<div class="modal-header">
+    <h5 class="modal-title">Sync with Sessionize</h5>
+    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+</div>
+<div class="modal-body">
+        <div class="mb-3">
+            <label for="event" class="form-label">Event</label>
+            <input value="#(event.id)" class="form-control" name="eventID" id="eventID" type="hidden" required>
+            <input value="#(event.name)" class="form-control" name="event" id="event" readonly>
+        </div>
+        
+        <ul class="list-unstyled mb-0">
+            #if(count(changes) == 0):
+            <div class="alert alert-secondary" role="alert">
+              There are no changes to be synced.
+            </div>
+            #endif
+            #for(change in changes):
+            <li class="d-flex align-items-center justify-content-between mb-4">
+                <div class="d-flex align-items-start me-3">
+                    <div class="bg-secondary rounded-1 p-2">
+                        <i class="bx #if(change.modelType == "speaker"):bx-microphone#else:bx-slideshow#endif fs-xl #if(change.operationType == "create"):text-success#else:text-danger#endif d-block"></i>
+                    </div>
+                    <div class="ps-3">
+                        #for(pair in change.pairs):
+                        <div class="fs-sm mb-1">
+                            <span class="fw-medium">#(pair.key)</span>: #(pair.newValue)
+                            
+                            #if(pair.oldValue):
+                            <em class="text-muted">was #(pair.oldValue)</em>
+                            #endif
+                        </div>
+                        #endfor
+                    </div>
+                </div>
+                
+                <input type="hidden" name="ids[]" value="#(change.id)" required>
+                <input type="hidden" name="statuses[]" value="enabled" required class="status">
+                        
+                <button type="button" data-swiftleeds-toggle="status" class="btn btn-icon btn-outline-success px-3 px-sm-4">
+                    <i class="bx bx-check fs-xl"></i>
+                </button>
+            </li>
+            #endfor
+        </ul>
+        
+        <script>
+        $("[data-swiftleeds-toggle='status']").on('click', (event) => {
+            const statusInput = $(event.currentTarget).parent().find('input.status');
+            
+            if($(event.currentTarget).hasClass('btn-outline-success')) {
+                statusInput.attr('value', 'disabled');
+            
+                $(event.currentTarget)
+                    .removeClass('btn-outline-success').addClass('btn-outline-danger')
+                    .find('i').removeClass('bx-check').addClass('bx-x');
+            } else {
+                statusInput.attr('value', 'enabled');
+            
+                $(event.currentTarget)
+                    .removeClass('btn-outline-danger').addClass('btn-outline-success')
+                    .find('i').removeClass('bx-x').addClass('bx-check');
+            }
+        });
+        </script>
+</div>
+<div class="modal-footer">
+    <button type="button" class="btn btn-success" data-swiftleeds-form="accept" #if(count(changes) == 0):disabled#endif>Accept changes</button>
+</div>
+</form>

--- a/Sources/App/Features/DropIns/Controllers/DropInRouteController.swift
+++ b/Sources/App/Features/DropIns/Controllers/DropInRouteController.swift
@@ -7,7 +7,167 @@ struct DropInRouteController: RouteCollection {
     }
     
     func boot(routes: RoutesBuilder) throws {
+        // Modal
+        routes.get(use: onRead)
+        routes.get(":id", use: onRead)
+        
+        // Print Out
         routes.get("print", ":id", use: onPrint)
+        
+        // Form
+        routes.post("create", use: onCreate)
+        routes.post(":id", "delete", use: onDelete)
+        routes.post(":id", "update", use: onUpdate)
+        
+        // Slots
+    }
+    
+    @Sendable private func onRead(request: Request) async throws -> View {
+        let session = try await request.parameters.get("id").map { id in
+            DropInSession.query(on: request.db)
+                .filter(\.$id == id)
+                .with(\.$slots)
+                .first()
+        }?.get()
+        
+        let events = try await Event.query(on: request.db).sort(\.$date).all()
+        let context = SessionContext(session: session, events: events)
+
+        return try await request.view.render("Admin/Form/dropin_form", context)
+    }
+    
+    @Sendable private func onDelete(request: Request) async throws -> Response {
+        guard let session = try await request.parameters.get("id").map({ id in
+            DropInSession.query(on: request.db)
+                .filter(\.$id == id)
+                .with(\.$slots)
+                .first()
+        })?.get() else { throw Abort(.notFound) }
+        
+        await withThrowingTaskGroup(of: Void.self) { group in
+            session.slots.forEach { slot in
+                group.addTask {
+                    try await slot.delete(on: request.db)
+                }
+            }
+        }
+        
+        try await session.delete(on: request.db)
+        return Response(status: .ok, body: .init(string: "OK"))
+    }
+    
+    @Sendable private func onCreate(request: Request) async throws -> Response {
+        return try await update(request: request, session: nil)
+    }
+    
+    @Sendable private func onUpdate(request: Request) async throws -> Response {
+        guard let session = try await DropInSession.find(request.parameters.get("id"), on: request.db) else {
+            throw Abort(.badRequest, reason: "Failed to find session")
+        }
+        
+        return try await update(request: request, session: session)
+    }
+    
+    private func update(request: Request, session: DropInSession?) async throws -> Response {
+        let input = try request.content.decode(FormInput.self)
+        let image = try request.content.decode(ImageInput.self)
+        
+        let mutableSession = session ?? DropInSession()
+        
+        if session == nil {
+            mutableSession.id = .generateRandom()
+        }
+        
+        guard let event = try await Event.find(.init(uuidString: input.eventID), on: request.db) else {
+            throw Abort(.badRequest, reason: "Failed to find event")
+        }
+        
+        mutableSession.title = input.title
+        mutableSession.description = input.description
+        mutableSession.isPublic = input.isPublic == "on"
+        mutableSession.$event.id = try event.requireID()
+        
+        mutableSession.maxTicketsPerSlot = {
+            if input.isBookable != "on" {
+                return 0
+            }
+            
+            if input.isGroup == "on" {
+                return input.groupSize ?? 0
+            }
+            
+            // Is bookable, and isn't a group, so it's a 1:1
+            return 1
+        }()
+        
+        mutableSession.exclusivityKey = {
+            // Handle manual overrides
+            if let existingKey = session?.exclusivityKey, existingKey != "G", existingKey != "A" {
+                return existingKey
+            }
+            
+            if input.isGroup == "on" {
+                return "G"
+            }
+            
+            return "A"
+        }()
+        
+        // Owner
+        mutableSession.owner = input.ownerName
+        mutableSession.ownerImageUrl = try await uploadAndReturnImage(image.ownerImage)
+        mutableSession.ownerLink = input.ownerLink
+        
+        // Company
+        if let companyName = input.companyName, let companyLink = input.companyLink {
+            mutableSession.company = companyName
+            mutableSession.companyImageUrl = try await uploadAndReturnImage(image.companyImage)
+            mutableSession.companyLink = companyLink
+        }
+        
+        // Update/Create
+        if session == nil {
+            try await mutableSession.create(on: request.db)
+        } else {
+            try await mutableSession.update(on: request.db)
+        }
+        
+        return Response(status: .ok, body: .init(string: "OK"))
+    }
+    
+    func uploadAndReturnImage(_ image: File?) async throws -> String? {
+        guard let image = image, image.filename != "" else { return nil }
+        
+        let fileName = "\(UUID.generateRandom().uuidString)-\(image.filename)"
+        try await ImageService.uploadFile(data: Data(image.data.readableBytesView), filename: fileName)
+        return fileName
+    }
+    
+    // MARK: - SessionContext
+    private struct SessionContext: Content {
+        let session: DropInSession?
+        let events: [Event]
+    }
+
+    // MARK: - ImageInput
+    private struct ImageInput: Content {
+        let ownerImage: File?
+        let companyImage: File?
+    }
+
+    // MARK: - FormInput
+    private struct FormInput: Content {
+        let title: String
+        let description: String
+        let ownerName: String
+        let ownerLink: String
+        let companyName: String?
+        let companyLink: String?
+        let isGroup: String?
+        let groupSize: Int?
+        let isPublic: String?
+        let isBookable: String?
+        let eventID: String
     }
 
     @Sendable private func onPrint(request: Request) async throws -> View {
@@ -34,10 +194,8 @@ struct DropInRouteController: RouteCollection {
             }
             
             return DropInSessionSlotsContext.Slot(
-                id: id,
                 date: $0.date,
-                owners: $0.ticketOwner,
-                isOwner: false
+                owners: $0.ticketOwner
             )
         }.sorted(by: { $0.date < $1.date }) // sort times so they're in order on the day
         
@@ -51,7 +209,7 @@ struct DropInRouteController: RouteCollection {
                 DropInSessionSlotsContext.SlotGroup(title: "Day \(offset + 1)", slots: result.value)
             }
         
-        let context = DropInSessionSlotsContext(session: .init(model: session), slots: slotModelsGrouped, prompt: nil)
+        let context = DropInSessionSlotsContext(session: .init(model: session), slots: slotModelsGrouped)
         return try await request.view.render("Admin/dropins-print", context)
     }
 }
@@ -61,47 +219,19 @@ struct DropInSessionViewModel: Codable {
     let title: String
     let description: String
     let owner: String
-    let ownerImageUrl: String?
-    let ownerLink: String?
-    let availability: String
-    let capacity: Int
     
     init(model: DropInSession) {
         self.id = model.id?.uuidString ?? ""
         self.title = model.title
         self.description = model.description
         self.owner = model.owner
-        self.ownerImageUrl = model.ownerImageUrl
-        self.ownerLink = model.ownerLink
-        self.availability = Self.generateAvailabilityString(
-            slotCount: model.slots.filter { $0.ticket.count < model.maxTicketsPerSlot }.count
-        )
-        self.capacity = model.maxTicketsPerSlot
     }
-    
-    static func generateAvailabilityString(slotCount: Int) -> String {
-        switch slotCount {
-        case 0:
-            return "No slots available"
-        case 1:
-            return "1 slot available"
-        default:
-            return "\(slotCount) slots available"
-        }
-    }
-}
-
-struct DropInSessionListContext: Content {
-    let sessions: [DropInSessionViewModel]
-    let hasValidTicket: Bool
 }
 
 struct DropInSessionSlotsContext: Content {
     struct Slot: Codable {
-        let id: String
         let date: Date
         let owners: [String]
-        let isOwner: Bool
     }
     
     struct SlotGroup: Codable {
@@ -111,5 +241,4 @@ struct DropInSessionSlotsContext: Content {
     
     let session: DropInSessionViewModel
     let slots: [SlotGroup]
-    let prompt: String?
 }

--- a/Sources/App/Features/DropIns/Models/DropInSession.swift
+++ b/Sources/App/Features/DropIns/Models/DropInSession.swift
@@ -46,6 +46,9 @@ final class DropInSession: Model, Content {
     @Field(key: "company_link")
     var companyLink: String?
     
+    @Field(key: "is_public")
+    var isPublic: Bool
+    
     @Parent(key: "event_id")
     public var event: Event
     

--- a/Sources/App/Features/DropIns/Models/Migrations/AddDropInTBAMigration.swift
+++ b/Sources/App/Features/DropIns/Models/Migrations/AddDropInTBAMigration.swift
@@ -1,0 +1,15 @@
+import Fluent
+
+final class AddDropInTBAMigration: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema(Schema.dropInSessions)
+            .field("is_public", .bool, .sql(.default(false)), .required) // default to hidden
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema(Schema.dropInSessions)
+            .deleteField("is_public")
+            .update()
+    }
+}

--- a/Sources/App/Features/Events/Controllers/EventRouteController.swift
+++ b/Sources/App/Features/Events/Controllers/EventRouteController.swift
@@ -43,7 +43,7 @@ struct EventRouteController: RouteCollection {
 
     private func update(request: Request, event: Event?) async throws -> Response {
         let input = try request.content.decode(FormInput.self)
-        let isCurrent = input.isCurrent ?? false
+        let isCurrent = input.isCurrent ?? event?.isCurrent ?? false
         var eventID: Event.IDValue
 
         guard let date = Self.formDateFormatter().date(from: input.date) else {
@@ -55,6 +55,7 @@ struct EventRouteController: RouteCollection {
             event.date = date
             event.location = input.location
             event.isCurrent = isCurrent
+            event.showSchedule = input.showSchedule ?? false
 
             eventID = try event.requireID()
 
@@ -96,5 +97,6 @@ struct EventRouteController: RouteCollection {
         let date: String
         let location: String
         let isCurrent: Bool?
+        let showSchedule: Bool?
     }
 }

--- a/Sources/App/Features/Events/Models/Event.swift
+++ b/Sources/App/Features/Events/Models/Event.swift
@@ -25,6 +25,12 @@ final class Event: Model, Content {
     @Field(key: "tito_event")
     var titoEvent: String?
     
+    @Field(key: "sessionize_key")
+    var sessionizeKey: String?
+    
+    @Field(key: "show_schedule")
+    var showSchedule: Bool
+    
     @Children(for: \.$event)
     var presentations: [Presentation]
 

--- a/Sources/App/Features/Events/Models/Migrations/Event+Migration+V4.swift
+++ b/Sources/App/Features/Events/Models/Migrations/Event+Migration+V4.swift
@@ -1,0 +1,17 @@
+import Fluent
+
+final class EventMigrationV4: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema(Schema.event)
+            .field("sessionize_key", .string)
+            .field("show_schedule", .bool, .sql(.default(false)), .required)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema(Schema.event)
+            .deleteField("sessionize_key")
+            .deleteField("show_schedule")
+            .update()
+    }
+}

--- a/Sources/App/Features/Home/HomeRouteController.swift
+++ b/Sources/App/Features/Home/HomeRouteController.swift
@@ -126,7 +126,7 @@ struct HomeRouteController: RouteCollection {
         try await DropInSession.query(on: req.db)
             .with(\.$event)
             .all()
-            .filter { $0.event.name == event.name }
+            .filter { $0.event.name == event.name && $0.isPublic }
     }
     
     private func getSlots(req: Request, event: Event) async throws -> [Slot] {

--- a/Sources/App/Features/Presentations/Controllers/PresentationRouteController.swift
+++ b/Sources/App/Features/Presentations/Controllers/PresentationRouteController.swift
@@ -53,7 +53,7 @@ struct PresentationRouteController: RouteCollection {
         if let presentation = presentation {
             presentation.title = input.title
             presentation.synopsis = input.synopsis
-            presentation.isTBA = false
+            presentation.isTBA = !(input.isAnnounced ?? false)
             presentation.slidoURL = input.slidoURL
             presentation.videoURL = input.videoURL
 
@@ -117,5 +117,6 @@ struct PresentationRouteController: RouteCollection {
         let synopsis: String
         let slidoURL: String?
         let videoURL: String?
+        let isAnnounced: Bool?
     }
 }

--- a/Sources/App/Features/Sessionize/Controllers/SessionizeSyncRouteController.swift
+++ b/Sources/App/Features/Sessionize/Controllers/SessionizeSyncRouteController.swift
@@ -1,0 +1,248 @@
+import Vapor
+
+struct SessionizeSyncRouteController: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get("modal", ":id", use: modal)
+        routes.post("modal", ":id", "accept", use: commit)
+    }
+    
+    @Sendable private func modal(request: Request) async throws -> View {
+        guard let event = try await Event.find(request.parameters.get("id"), on: request.db) else { throw Abort(.notFound) }
+        
+        guard let key = event.sessionizeKey else { throw Abort(.badRequest, reason: "No Sessionize Key for Event") }
+        let sessionizeResponse = try await request.client.get("https://sessionize.com/api/v2/\(key)/view/All")
+        let sessionize = try sessionizeResponse.content.decode(SessionizeResponse.self)
+        let changes = try await identifyChanges(sessionize: sessionize, request: request, commit: [], event: event)
+        
+        let context = SyncContext(changes: changes, event: event)
+        return try await request.view.render("Admin/sync_modal", context)
+    }
+    
+    @Sendable private func commit(request: Request) async throws -> Response {
+        guard let event = try await Event.find(request.parameters.get("id"), on: request.db) else { throw Abort(.notFound) }
+        
+        let input = try request.content.decode(FormInput.self)
+        let commitIds = zip(input.ids, input.statuses).filter { $0.1 == "enabled" }.map { $0.0 }
+        
+        guard let key = event.sessionizeKey else { throw Abort(.badRequest, reason: "No Sessionize Key for Event") }
+        let sessionizeResponse = try await request.client.get("https://sessionize.com/api/v2/\(key)/view/All")
+        let sessionize = try sessionizeResponse.content.decode(SessionizeResponse.self)
+        let changes = try await identifyChanges(sessionize: sessionize, request: request, commit: commitIds, event: event)
+        
+        return Response(status: .ok, body: .init(string: "OK"))
+    }
+    
+    private func identifyChanges(sessionize: SessionizeResponse, request: Request, commit: [String], event: Event) async throws -> [SyncContext.Change] {
+        var changes = [SyncContext.Change]()
+        
+        for sessionizeSpeaker in sessionize.speakers {
+            let id = UUID(uuidString: sessionizeSpeaker.id)!
+            
+            let speakerQuery = try await Speaker
+                .query(on: request.db)
+                .group(.or, { $0
+                    .filter(\.$name, .equal, sessionizeSpeaker.fullName)
+                    .filter(\.$id, .equal, UUID(uuidString: sessionizeSpeaker.id)!)
+                })
+                .first()
+            
+            let twitter = sessionizeSpeaker.links.first(where: { $0.linkType == "Twitter" })?.url.replacingOccurrences(of: "https://twitter.com/", with: "")
+            
+            if var speaker = speakerQuery {
+                var pairs = [SyncContext.Pair]()
+                
+                if speaker.name != sessionizeSpeaker.fullName {
+                    pairs.append(.init(key: "Name", oldValue: speaker.name, newValue: sessionizeSpeaker.fullName))
+                    speaker.name = sessionizeSpeaker.fullName
+                }
+                
+                if speaker.biography != sessionizeSpeaker.bio {
+                    pairs.append(.init(key: "Biography", oldValue: speaker.biography, newValue: sessionizeSpeaker.bio))
+                    speaker.biography = sessionizeSpeaker.bio
+                }
+                
+                if speaker.organisation != sessionizeSpeaker.tagLine {
+                    pairs.append(.init(key: "Organisation", oldValue: speaker.organisation, newValue: sessionizeSpeaker.tagLine))
+                    speaker.organisation = sessionizeSpeaker.tagLine
+                }
+                
+                if speaker.twitter != twitter {
+                    pairs.append(.init(key: "Twitter", oldValue: speaker.twitter ?? "-- Not Defined --", newValue: twitter ?? "-- Not Defined --"))
+                    speaker.twitter = twitter
+                }
+                
+                if pairs.isEmpty == false {
+                    changes.append(.init(id: sessionizeSpeaker.id, modelType: .speaker, operationType: .update, pairs: pairs))
+                }
+                
+                if commit.contains(sessionizeSpeaker.id) {
+                    try await speaker.update(on: request.db)
+                }
+            } else {
+                let newSpeaker = Speaker(
+                    id: id,
+                    name: sessionizeSpeaker.fullName,
+                    biography: sessionizeSpeaker.bio,
+                    profileImage: "",
+                    organisation: sessionizeSpeaker.tagLine,
+                    twitter: twitter
+                )
+                
+                changes.append(.init(
+                    id: sessionizeSpeaker.id,
+                    modelType: .speaker,
+                    operationType: .create,
+                    pairs: [
+                        .init(key: "Name", oldValue: nil, newValue: sessionizeSpeaker.fullName),
+                        .init(key: "Biography", oldValue: nil, newValue: sessionizeSpeaker.bio),
+                        .init(key: "Organisation", oldValue: nil, newValue: sessionizeSpeaker.tagLine),
+                        .init(key: "Twitter", oldValue: nil, newValue: newSpeaker.twitter ?? "-- Not Defined --")
+                    ]
+                ))
+                
+                if commit.contains(sessionizeSpeaker.id) {
+                    guard let data = try await request.client.get(URI(string: sessionizeSpeaker.profilePicture.absoluteString)).body else {
+                        throw Abort(.badRequest, reason: "failed to download image")
+                    }
+                    
+                    let fileName = sessionizeSpeaker.profilePicture.absoluteString.components(separatedBy: "/").last!
+                    try await ImageService.uploadFile(data: Data(buffer: data), filename: fileName)
+                    newSpeaker.profileImage = fileName
+                    
+                    try await newSpeaker.create(on: request.db)
+                }
+            }
+        }
+        
+        for sessionizeSession in sessionize.sessions {
+            let sessionQuery = try await Presentation
+                .query(on: request.db)
+                .filter(\.$title, .equal, sessionizeSession.title)
+                .first()
+            
+            if let session = sessionQuery {
+                var pairs = [SyncContext.Pair]()
+                
+                if session.synopsis != sessionizeSession.description {
+                    pairs.append(.init(key: "Description", oldValue: session.synopsis, newValue: sessionizeSession.description))
+                    session.synopsis = sessionizeSession.description
+                }
+                
+                if pairs.isEmpty == false {
+                    changes.append(.init(id: sessionizeSession.id, modelType: .presentation, operationType: .update, pairs: pairs))
+                }
+                
+                if commit.contains(sessionizeSession.id) {
+                    try await session.update(on: request.db)
+                }
+            } else {
+                let newSession = Presentation(
+                    id: .generateRandom(),
+                    title: sessionizeSession.title,
+                    synopsis: sessionizeSession.description,
+                    isTBA: true,
+                    slidoURL: nil,
+                    videoURL: nil
+                )
+                
+                let speakers = sessionize.speakers
+                    .filter { sessionizeSession.speakers.contains($0.id) }
+                    .map { $0.fullName }
+                
+                changes.append(.init(
+                    id: sessionizeSession.id,
+                    modelType: .presentation,
+                    operationType: .create,
+                    pairs: [
+                        .init(key: "Title", oldValue: nil, newValue: sessionizeSession.title),
+                        .init(key: "Description", oldValue: nil, newValue: sessionizeSession.description),
+                        .init(key: "Speakers", oldValue: nil, newValue: speakers.joined(separator: " and "))
+                    ]
+                ))
+                
+                if commit.contains(sessionizeSession.id) {
+                    newSession.$event.id = try event.requireID()
+                    
+                    var modelSpeakers: [Speaker] = []
+                    
+                    for speaker in speakers {
+                        guard var speaker = try await Speaker.query(on: request.db).filter(\.$name, .equal, speaker).first() else {
+                            throw Abort(.badRequest, reason: "Failed to find speaker")
+                        }
+                        
+                        modelSpeakers.append(speaker)
+                    }
+                    
+                    if modelSpeakers.count >= 1 {
+                        newSession.$speaker.id = try modelSpeakers[0].requireID()
+                    }
+                    
+                    if modelSpeakers.count == 2 {
+                        newSession.$secondSpeaker.id = try modelSpeakers[1].requireID()
+                    }
+                    
+                    try await newSession.create(on: request.db)
+                }
+            }
+        }
+        
+        return changes
+    }
+    
+    private struct FormInput: Content {
+        let ids: [String]
+        let statuses: [String]
+    }
+    
+    struct SyncContext: Content {
+        enum ModelType: String, Codable {
+            case speaker, presentation
+        }
+        
+        enum OperationType: String, Codable {
+            case create, update
+        }
+        
+        struct Pair: Codable {
+            let key: String
+            let oldValue: String?
+            let newValue: String
+        }
+        
+        struct Change: Codable {
+            let id: String
+            let modelType: ModelType
+            let operationType: OperationType
+            let pairs: [Pair]
+        }
+        
+        let changes: [Change]
+        let event: Event
+    }
+    
+    struct SessionizeResponse: Decodable {
+        struct Link: Decodable {
+            let linkType: String
+            let url: String
+        }
+        
+        struct Speaker: Decodable {
+            let id: String
+            let fullName: String
+            let bio: String
+            let tagLine: String
+            let links: [Link]
+            let profilePicture: URL
+        }
+        
+        struct Session: Decodable {
+            let id: String
+            let title: String
+            let description: String
+            let speakers: [String]
+        }
+        
+        let sessions: [Session]
+        let speakers: [Speaker]
+    }
+}

--- a/Sources/App/Features/Ticket Hub/Controllers/TicketHubRouteController.swift
+++ b/Sources/App/Features/Ticket Hub/Controllers/TicketHubRouteController.swift
@@ -28,6 +28,7 @@ struct TicketHubRouteController: RouteCollection {
                     .with(\.$slots)
                     .sort(.id)
                     .all()
+                    .filter { $0.isPublic }
                 
                 let dropInSessions = sessions.filter { $0.maxTicketsPerSlot == 1 }.map { convertDropInSessionToViewModel($0, slug: ticket.slug) }
                 let groupSessions = sessions.filter { $0.maxTicketsPerSlot > 1 }.map { convertDropInSessionToViewModel($0, slug: ticket.slug) }

--- a/Sources/App/Migrations.swift
+++ b/Sources/App/Migrations.swift
@@ -75,6 +75,7 @@ class Migrations {
         app.migrations.add(EventMigrationV3()) // Adds tito ID
         app.migrations.add(UseArrayDropInOwnerMigration()) // Use arrays for slot owners
         app.migrations.add(AddDurationToDropInMigration()) // Add duration to slot
+        app.migrations.add(AddDropInTBAMigration()) // Hide drop-in by default
         app.migrations.add(EventMigrationV4()) // Add sessionize_key and show_schedule
 
         do {

--- a/Sources/App/Migrations.swift
+++ b/Sources/App/Migrations.swift
@@ -75,6 +75,7 @@ class Migrations {
         app.migrations.add(EventMigrationV3()) // Adds tito ID
         app.migrations.add(UseArrayDropInOwnerMigration()) // Use arrays for slot owners
         app.migrations.add(AddDurationToDropInMigration()) // Add duration to slot
+        app.migrations.add(EventMigrationV4()) // Add sessionize_key and show_schedule
 
         do {
             guard let url = Environment.get("DATABASE_URL") else {

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -48,6 +48,7 @@ func routes(_ app: Application) throws {
     try adminRoutes.grouped("activities").register(collection: ActivityRouteController())
     try adminRoutes.grouped("jobs").register(collection: JobRouteController())
     try adminRoutes.grouped("dropins").register(collection: DropInRouteController())
+    try adminRoutes.grouped("sessionize").register(collection: SessionizeSyncRouteController())
 
     adminRoutes.get { request -> View in
         let user = try request.auth.require(User.self)

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -84,6 +84,7 @@ func routes(_ app: Application) throws {
         
         let dropInSessions = try await DropInSession.query(on: request.db)
             .with(\.$event)
+            .with(\.$slots)
             .all()
 
         return try await request.view.render(


### PR DESCRIPTION
- [x] Add `showSchedule` to Event (was previously hardcoded)
- [x] Add `isPublic` to Drop-In Sessions (allows us to add to database and publish separately)
- [x] Add Drop-In Session Create/Edit Forms
    - [x] Add "Is Bookable" override to disable attendance and lock to 0
    - [x] Manage Slots
- [x] Add `isPublic` to Presentation Edit Form
- [x] Add Sessionize Sync for Presentations + Speakers
    - `isPublic` defaults to `false` meaning no presentation is shown until manually toggled
- [x] Default 'Event' in forms to current dashboard filter
    - This means when you create a slot, sponsor, etc, it will use the event you have in the filter in the sidebar
    - You can move the entity to a different event if you edit the event afterwards
- [x] Add confirmation dialogs for all delete actions

Not for this PR:
- [ ] Add admin dashboard with basic ticket and check-in metrics
- [ ] Add `titoCheckInKey` to Event (currently in EnvVar)
- [ ] Add ability to send push notifications
- [ ] Add visual/interactive calendar view for slots editor