### PR TITLE
Replace Cookie Name

### DIFF
--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -5,6 +5,8 @@ import Vapor
 
 public func configure(_ app: Application) throws {
     // Sessions
+    // https://firebase.google.com/docs/hosting/manage-cache#using_cookies
+    app.sessions.configuration.cookieName = "__session"
     app.sessions.use(.fluent(.psql))
     
     // Middleware


### PR DESCRIPTION
This was a bitch to debug, but looks like our sessions are being ignored only when routed through Firebase Hosting due to this little asterisks at the bottom of a docs page.

Can't test locally, but login and session storage does (continue to) work. Hopefully fixes production.