### PR TITLE
Move deployment to Belgium DC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Login to Google Artifact Registry
         uses: docker/login-action@v3
         with:
-          registry: europe-west2-docker.pkg.dev
+          registry: europe-west1-docker.pkg.dev
           username: _json_key
           password: ${{ secrets.GAR_JSON_KEY }}
 
@@ -34,7 +34,7 @@ jobs:
           context: .
           push: true
           provenance: false
-          tags: europe-west2-docker.pkg.dev/swiftleeds-website/swiftleeds-web/web:${{ github.head_ref || github.ref_name }}-latest
+          tags: europe-west1-docker.pkg.dev/swiftleeds-website/swiftleeds-web/web:${{ github.head_ref || github.ref_name }}-latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -64,9 +64,9 @@ jobs:
         id: deploy
         uses: google-github-actions/deploy-cloudrun@v2
         with:
-          service: swiftleeds-web-${{ github.head_ref || github.ref_name }}
-          region: europe-west2
-          image: europe-west2-docker.pkg.dev/swiftleeds-website/swiftleeds-web/web:${{ github.head_ref || github.ref_name }}-latest
+          service: swiftleeds-web-${{ github.head_ref || github.ref_name }}-be
+          region: europe-west1
+          image: europe-west1-docker.pkg.dev/swiftleeds-website/swiftleeds-web/web:${{ github.head_ref || github.ref_name }}-latest
           flags: "--allow-unauthenticated"
           env_vars: |
             BUCKET_NAME_PRESENTATIONS=swiftleeds-presentations


### PR DESCRIPTION
Brexit has reached SwiftLeeds! (No, it's unrelated).

We currently deploy into `europe-west1`, this is in London and gives the best possible speeds to our UK audience. However, this region does not support Google Cloud Run domain mapping. 

For this reason, we use Firebase Hosting as an additional layer on top of GCR. It does nothing but define a basic mapping between a custom domain and this service.

However this has caused us a few pain points over the time in which this has been deployed, notably:
1. It overrides your `apple-app-site-association` (fixed in https://github.com/SwiftLeeds/swiftleeds-web/commit/a949d14b3dd947d34224bdf6c0e15370faf30e36)
2. It tweaks how your cookies are stored (fixed in https://github.com/SwiftLeeds/swiftleeds-web/pull/135/commits/b9af785cb011c24654161057898c2a7ba960ba8e)

By moving to `europe-west2`, which is in Belgium, we can get rid of this extra layer of complexity, revert (or leave, it doesn't actually matter) these fixes, benefit from one less cost on our budget, and provide me with one less migraine. To be clear, this is because `europe-west2` is one of the ten regions supported by GCR custom domain mapping (https://cloud.google.com/run/docs/mapping-custom-domains).

This does have a very small penalty in terms of latency, but using https://www.gcping.com/ this is a matter of 2ms which is completely negligible in the grand scheme of things.

--

## Important Notes

1. I'm going to let this branch deploy to ensure the artifact registry is ready
2. I've suffixed the service name with `-be` to ensure no conflict between the Belgium and London services
3. I will update the domain mapping in Google Cloud Run, at which point Adam can update the DNS at any time and it should just switch which service the traffic goes to.
4. Once complete, we can delete the `-be` suffix, all London services, all Firebase projects, etm.