### PR TITLE
Slot property deprecations & migration fixes

### DIFF
--- a/Sources/App/Features/Slots/Controllers/SlotRouteController.swift
+++ b/Sources/App/Features/Slots/Controllers/SlotRouteController.swift
@@ -87,9 +87,7 @@ struct SlotRouteController: RouteCollection {
         
         let mutableSlot = slot ?? Slot()
         mutableSlot.startDate = input.startTime
-        mutableSlot.date = inputDate
         mutableSlot.duration = duration
-        mutableSlot.$event.id = try event.requireID()
         mutableSlot.$day.id = try eventDay.requireID()
         
         if let activity {

--- a/Sources/App/Features/Slots/Migrations/Slot+Migration+v6.swift
+++ b/Sources/App/Features/Slots/Migrations/Slot+Migration+v6.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Fluent
+
+struct SlotMigrationV6: AsyncMigration {
+    func prepare(on db: Database) async throws {
+        try await db.schema(Schema.slot)
+            .deleteField("date")
+            .deleteField("event_id")
+            .update()
+    }
+
+    func revert(on db: Database) async throws {
+        try await db.schema(Schema.slot)
+            .field("date", .datetime)
+            .field("event_id", .uuid, .references(Schema.event, "id"))
+            .update()
+
+    }
+}

--- a/Sources/App/Features/Slots/Models/Slot.swift
+++ b/Sources/App/Features/Slots/Models/Slot.swift
@@ -15,16 +15,16 @@ final class Slot: Codable, Model, Content, @unchecked Sendable {
     
     // DO NOT USE (June 2024)
     // TODO: This will be removed in a future PR as part of a cleanup
-    @Field(key: "date")
-    var date: Date?
+//    @Field(key: "date")
+//    var date: Date?
 
     @Field(key: "duration")
     var duration: Double?
 
     // DO NOT USE (June 2024)
     // TODO: This will be removed in a future PR as part of a cleanup - it needs to be done this way for safe migrations.
-    @OptionalParent(key: "event_id")
-    var event: Event?
+//    @OptionalParent(key: "event_id")
+//    var event: Event?
     
     @OptionalParent(key: "day_id")
     var day: EventDay?
@@ -40,23 +40,26 @@ final class Slot: Codable, Model, Content, @unchecked Sendable {
     init(
         id: IDValue?,
         startDate: String,
-        date: Date,
         duration: Double?
     ) {
         self.id = id
         self.startDate = startDate
-        self.date = date
         self.duration = duration
     }
 }
 
 extension Array where Element == Slot {
     var schedule: [[Slot]] {
-        let dates = Set(compactMap { $0.date?.withoutTime }).sorted(by: (<))
+        let dates = Set(compactMap { $0.day?.date.withoutTime }).sorted()
         var slots: [[Slot]] = []
 
         for date in dates {
-            slots.append(filter { Calendar.current.compare(date, to: $0.date ?? Date(), toGranularity: .day) == .orderedSame })
+            slots.append(
+                filter {
+                    guard let slotDate = $0.day?.date else { return false }
+                    return Calendar.current.isDate(slotDate, inSameDayAs: date)
+                }
+            )
         }
 
         return slots

--- a/Sources/App/Features/Slots/Models/Slot.swift
+++ b/Sources/App/Features/Slots/Models/Slot.swift
@@ -12,19 +12,9 @@ final class Slot: Codable, Model, Content, @unchecked Sendable {
 
     @Field(key: "start_date")
     var startDate: String
-    
-    // DO NOT USE (June 2024)
-    // TODO: This will be removed in a future PR as part of a cleanup
-//    @Field(key: "date")
-//    var date: Date?
 
     @Field(key: "duration")
     var duration: Double?
-
-    // DO NOT USE (June 2024)
-    // TODO: This will be removed in a future PR as part of a cleanup - it needs to be done this way for safe migrations.
-//    @OptionalParent(key: "event_id")
-//    var event: Event?
     
     @OptionalParent(key: "day_id")
     var day: EventDay?

--- a/Sources/App/Features/Slots/Transformers/SlotTransformer.swift
+++ b/Sources/App/Features/Slots/Transformers/SlotTransformer.swift
@@ -28,7 +28,7 @@ enum SlotTransformer: Transformer {
         return .init(
             id: id,
             startTime: entity.startDate,
-            date: entity.date,
+            date: entity.day?.date,
             duration: entity.presentation?.duration ?? entity.activity?.duration ?? entity.duration ?? 0,
             presentation: presentation,
             activity: activity

--- a/Sources/App/Migrations.swift
+++ b/Sources/App/Migrations.swift
@@ -83,6 +83,7 @@ class Migrations {
         app.migrations.add(SpeakerMigrationV2()) // Add more social link options
         app.migrations.add(SlotMigrationV5()) // Remove unneeded slot_id params
         app.migrations.add(PresentationMigrationV6()) // Add video visibility
+        app.migrations.add(SlotMigrationV6()) // Remove legacy date and event_id fields
 
         do {
             guard let url = Environment.get("DATABASE_URL") else {

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -86,12 +86,15 @@ func routes(_ app: Application) throws {
             .all()
         let slots = try await Slot
             .query(on: request.db)
-            .sort(\.$date)
             .sort(\.$startDate)
             .with(\.$day)
             .with(\.$presentation)
             .with(\.$activity)
             .all()
+            .sorted {
+                guard let d1 = $0.day?.date, let d2 = $1.day?.date else { return false }
+                return d1 < d2
+            }
         let activities = try await Activity
             .query(on: request.db)
             .sort(\.$event.$id, .descending) // This moves 'Reusable' events to the top of the filtered view


### PR DESCRIPTION
Noticed during a fresh setup of this locally we had a few issues with migrations running related to deprecated properties on Slot. 

I've updated the migrations to be entirely work from a fresh install and (hopefully) work on existing deployments, and fixed the fully commented out migration with a fatalError in it to stop it running, hopefully all works _as expected_ now, famous last words, but all looks good from my side and I can create all things in my local Admin and see them on the website.

Note, this **does** break the seeder, I spent a bit of time trying to manually fix the SQL but I think I'll just replicate production manually by hand and then dump that SQL to get a fully correct version with 2024 and 2025's entries on as well anyways (but probably closer to the event to not leak anything 🤐).

I tried to break down the changes commit by commit to give an idea of the changes but any questions please give me a shout in case I've messed up some ordering or foreign keys based on what fields were deprecated etc.

(Example that changes are working for Slots on my local with a limited database)

| Admin | Website |
| ---- | ---- 
<img width="1374" height="827" alt="Screenshot 2025-07-16 at 23 44 41" src="https://github.com/user-attachments/assets/1c3fdf44-179b-489b-9938-8173d4bf73ef" /> | <img width="1390" height="750" alt="Screenshot 2025-07-16 at 23 44 50" src="https://github.com/user-attachments/assets/0d75c91d-eaf4-4a67-943c-beb13a593521" />
