### PR TITLE
Add tito webhook and slack integration

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f34b43daf638947218dcf50309c6b0f3bdd54b3f76e7050ef8b16d1a53ee1b5b",
+  "originHash" : "0caf82d226638e419ff1db9491551c36f086292766f211369151d0685e4d2ace",
   "pins" : [
     {
       "identity" : "apns",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server-community/APNSwift.git",
       "state" : {
-        "revision" : "f407b435d28456c2568cc2713a226cd06a5d5736",
-        "version" : "6.1.0"
+        "revision" : "eb302f9dfa5ad44270496fef12edbe7036f67dd5",
+        "version" : "6.2.0"
       }
     },
     {

--- a/Sources/App/Features/Utilities/SlackMessage.swift
+++ b/Sources/App/Features/Utilities/SlackMessage.swift
@@ -1,6 +1,5 @@
 import Vapor
 
-// MARK: - SlackMessage
 struct SlackMessage: Content {
     let channel: String
     let icon_emoji: String
@@ -17,7 +16,8 @@ struct SlackMessage: Content {
         }
         
         enum BlockType: String, Content {
-            case section, divider
+            case divider
+            case section
         }
         
         struct SlackText: Content {
@@ -32,9 +32,13 @@ struct SlackMessage: Content {
 }
 
 // MARK: - Send message
+
 extension SlackMessage {
     func send(req: Request) async throws {
-        guard let slackWebhook = Environment.get("SLACK_WEBHOOK") else { throw Abort(.notFound) }
+        guard let slackWebhook = Environment.get("SLACK_WEBHOOK") else {
+            throw Abort(.notFound)
+        }
+        
         _ = try await req.client.post(URI(string: slackWebhook), content: self)
     }
 }

--- a/Sources/App/Features/Utilities/SlackMessage.swift
+++ b/Sources/App/Features/Utilities/SlackMessage.swift
@@ -1,0 +1,40 @@
+import Vapor
+
+// MARK: - SlackMessage
+struct SlackMessage: Content {
+    let channel: String
+    let icon_emoji: String
+    let username: String
+    let blocks: [SlackBlock]
+    
+    struct SlackBlock: Content {
+        let type: BlockType
+        let text: SlackText?
+        
+        init(type: BlockType, text: SlackText? = nil) {
+            self.type = type
+            self.text = text
+        }
+        
+        enum BlockType: String, Content {
+            case section, divider
+        }
+        
+        struct SlackText: Content {
+            let type: TextType
+            let text: String
+            
+            enum TextType: String, Content {
+                case markdown = "mrkdwn"
+            }
+        }
+    }
+}
+
+// MARK: - Send message
+extension SlackMessage {
+    func send(req: Request) async throws {
+        guard let slackWebhook = Environment.get("SLACK_WEBHOOK") else { throw Abort(.notFound) }
+        _ = try await req.client.post(URI(string: slackWebhook), content: self)
+    }
+}

--- a/Sources/App/Features/Webhook/Controllers/WebhookRouteController.swift
+++ b/Sources/App/Features/Webhook/Controllers/WebhookRouteController.swift
@@ -1,0 +1,102 @@
+import Vapor
+
+struct WebhookRouteController: RouteCollection {
+    func boot(routes: any RoutesBuilder) throws {
+        routes.post("webhook", use: onReceive)
+    }
+    
+    @Sendable private func onReceive(request: Request) async throws -> String {
+        guard let webhookName = request.headers["x-webhook-name"].first else { return "No webhook name found" }
+        guard let titoWebhook = TitoWebhook(rawValue: webhookName) else { return "Webhook name not recognised" }
+        
+        switch titoWebhook {
+        case .checkinCreated, .checkinDeleted:
+            break
+        case .ticketCreated, .ticketCompleted, .ticketReassigned, .ticketUpdated, .ticketUnsnoozed, .ticketUnvoided, .ticketVoided:
+            break
+        case .registrationUpdated, .registrationFinished, .registrationCompleted, .registrationCancelled, .registrationMarkedAsPaid, .registrationMarkedAsUnpaid:
+            try await handleRegistrationUpdate(req: request, webhook: titoWebhook)
+        }
+        
+        return ""
+    }
+    
+    @Sendable func handleRegistrationUpdate(req: Request, webhook: TitoWebhook) async throws {
+        guard let ticketChannel = Environment.get("TICKET_CHANNEL") else { throw Abort(.notFound) }
+        
+        let registration = try req.content.decode(TitoRegistration.self)
+        
+        let message = generateRegistrationMessage(for: registration)
+        let details = generateRegistrationDetails(for: registration)
+        
+        let slackMessage = SlackMessage(channel: ticketChannel, icon_emoji: ":admission_tickets:", username: registration.event.title, blocks: [
+            .init(type: .section, text: .init(type: .markdown, text: message)),
+            .init(type: .section, text: .init(type: .markdown, text: details)),
+            .init(type: .divider)
+        ])
+        
+        try await slackMessage.send(req: req)
+    }
+    
+    @Sendable private func generateRegistrationMessage(for registration: TitoRegistration) -> String {
+        var message = "*\(registration.fullName)* "
+        
+        if registration.email.isEmpty == false {
+            message += "<\(registration.email)> "
+        }
+        
+        if let companyName = registration.company_name {
+            message += "from \(companyName) "
+        }
+        
+        message += "registered \(registration.tickets.count) ticket\(registration.tickets.count > 1 ? "s" : "") "
+        message += "(<https://dashboard.tito.io/\(registration.event.account_slug)/\(registration.event.slug)/registrations/\(registration.slug)|Tito Dashboard>)"
+        
+        if registration.test_mode {
+            message = "[TEST] \(message)"
+        }
+        
+        return message
+    }
+    
+    @Sendable private func generateRegistrationDetails(for registration: TitoRegistration) -> String {
+        var details = ""
+        
+        registration.tickets.forEach { ticket in
+            details += "_• \(ticket.release_title) "
+            
+            if let fullName = ticket.fullName {
+                details += "[\(fullName)]"
+            } else {
+                details += "[Unassigned]"
+            }
+            
+            if let upgrades = ticket.upgrades {
+                details.append(" + \(upgrades.map { $0.title }.joined(separator: ","))")
+            }
+            
+            details += "_\n"
+        }
+        
+        return details
+    }
+    
+    // MARK: - TitoWebhook
+    enum TitoWebhook: String {
+        case checkinCreated = "checkin.created"
+        case checkinDeleted = "checkin.deleted"
+        case ticketCreated = "ticket.created"
+        case ticketCompleted = "ticket.completed"
+        case ticketReassigned = "ticket.reassigned"
+        case ticketUpdated = "ticket.updated"
+        case ticketUnsnoozed = "ticket.unsnoozed"
+        case ticketUnvoided = "ticket.unvoided"
+        case ticketVoided = "ticket.voided"
+        case registrationUpdated = "registration.updated"
+        case registrationFinished = "registration.finished"
+        case registrationCompleted = "registration.completed"
+        case registrationCancelled = "registration.cancelled"
+        case registrationMarkedAsPaid = "registration.marked_as_paid"
+        case registrationMarkedAsUnpaid = "registration.marked_as_unpaid"
+    }
+}

--- a/Sources/App/Features/Webhook/Controllers/WebhookRouteController.swift
+++ b/Sources/App/Features/Webhook/Controllers/WebhookRouteController.swift
@@ -41,10 +41,6 @@ struct WebhookRouteController: RouteCollection {
     @Sendable private func generateRegistrationMessage(for registration: TitoRegistration) -> String {
         var message = "*\(registration.fullName)* "
         
-        if registration.email.isEmpty == false {
-            message += "<\(registration.email)> "
-        }
-        
         if let companyName = registration.company_name {
             message += "from \(companyName) "
         }

--- a/Sources/App/Features/Webhook/Controllers/WebhookRouteController.swift
+++ b/Sources/App/Features/Webhook/Controllers/WebhookRouteController.swift
@@ -6,23 +6,28 @@ struct WebhookRouteController: RouteCollection {
     }
     
     @Sendable private func onReceive(request: Request) async throws -> String {
-        guard let webhookName = request.headers["x-webhook-name"].first else { return "No webhook name found" }
-        guard let titoWebhook = TitoWebhook(rawValue: webhookName) else { return "Webhook name not recognised" }
+        guard let webhookName = request.headers["x-webhook-name"].first else {
+            return "No webhook name found"
+        }
+        
+        guard let titoWebhook = TitoWebhook(rawValue: webhookName) else {
+            return "Webhook name not recognised"
+        }
         
         switch titoWebhook {
-        case .checkinCreated, .checkinDeleted:
+        case .registrationFinished:
+            try await handleRegistrationUpdate(req: request)
+        default:
             break
-        case .ticketCreated, .ticketCompleted, .ticketReassigned, .ticketUpdated, .ticketUnsnoozed, .ticketUnvoided, .ticketVoided:
-            break
-        case .registrationUpdated, .registrationFinished, .registrationCompleted, .registrationCancelled, .registrationMarkedAsPaid, .registrationMarkedAsUnpaid:
-            try await handleRegistrationUpdate(req: request, webhook: titoWebhook)
         }
         
         return ""
     }
     
-    @Sendable func handleRegistrationUpdate(req: Request, webhook: TitoWebhook) async throws {
-        guard let ticketChannel = Environment.get("TICKET_CHANNEL") else { throw Abort(.notFound) }
+    @Sendable private func handleRegistrationUpdate(req: Request) async throws {
+        guard let ticketChannel = Environment.get("TICKET_CHANNEL") else {
+            throw Abort(.notFound)
+        }
         
         let registration = try req.content.decode(TitoRegistration.self)
         
@@ -32,7 +37,7 @@ struct WebhookRouteController: RouteCollection {
         let slackMessage = SlackMessage(channel: ticketChannel, icon_emoji: ":admission_tickets:", username: registration.event.title, blocks: [
             .init(type: .section, text: .init(type: .markdown, text: message)),
             .init(type: .section, text: .init(type: .markdown, text: details)),
-            .init(type: .divider)
+            .init(type: .divider),
         ])
         
         try await slackMessage.send(req: req)
@@ -58,7 +63,7 @@ struct WebhookRouteController: RouteCollection {
     @Sendable private func generateRegistrationDetails(for registration: TitoRegistration) -> String {
         var details = ""
         
-        registration.tickets.forEach { ticket in
+        for ticket in registration.tickets {
             details += "_• \(ticket.release_title) "
             
             if let fullName = ticket.fullName {
@@ -68,7 +73,7 @@ struct WebhookRouteController: RouteCollection {
             }
             
             if let upgrades = ticket.upgrades {
-                details.append(" + \(upgrades.map { $0.title }.joined(separator: ","))")
+                details.append(" + \(upgrades.map(\.title).joined(separator: ","))")
             }
             
             details += "_\n"
@@ -78,6 +83,7 @@ struct WebhookRouteController: RouteCollection {
     }
     
     // MARK: - TitoWebhook
+        
     enum TitoWebhook: String {
         case checkinCreated = "checkin.created"
         case checkinDeleted = "checkin.deleted"

--- a/Sources/App/Features/Webhook/Models/TitoRegistration.swift
+++ b/Sources/App/Features/Webhook/Models/TitoRegistration.swift
@@ -28,7 +28,10 @@ struct TitoRegistration: Decodable {
         let upgrades: [Upgrade]?
         
         var fullName: String? {
-            guard let first_name, let last_name else { return nil }
+            guard let first_name, let last_name else {
+                return nil
+            }
+            
             return "\(first_name) \(last_name)"
         }
         

--- a/Sources/App/Features/Webhook/Models/TitoRegistration.swift
+++ b/Sources/App/Features/Webhook/Models/TitoRegistration.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+struct TitoRegistration: Decodable {
+    let id: Int
+    let slug: String
+    let reference: String
+    let first_name: String
+    let last_name: String
+    let email: String
+    let company_name: String?
+    let test_mode: Bool
+    let tickets: [Ticket]
+    let event: Event
+    
+    var fullName: String {
+        return "\(first_name) \(last_name)"
+    }
+    
+    struct Ticket: Decodable {
+        let slug: String
+        let reference: String
+        let release_title: String
+        let first_name: String?
+        let last_name: String?
+        let email: String?
+        let company_name: String?
+        let job_title: String?
+        let upgrades: [Upgrade]?
+        
+        var fullName: String? {
+            guard let first_name, let last_name else { return nil }
+            return "\(first_name) \(last_name)"
+        }
+        
+        struct Upgrade: Decodable {
+            let title: String
+        }
+    }
+
+    struct Event: Decodable {
+        let id: Int
+        let account_slug: String
+        let slug: String
+        let title: String
+        let url: String
+    }
+}
+
+struct RegistrationResponse: Decodable {
+    let ticket: TitoTicket
+}

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -24,6 +24,8 @@ func routes(_ app: Application) throws {
     try apiV2Routes.grouped("schedule").register(collection: ScheduleAPIControllerV2())
     try apiV2Routes.grouped("team").register(collection: TeamAPIController())
     
+    try app.routes.register(collection: WebhookRouteController())
+    
     app.get("robots.txt") { _ -> String in
         let disallowedPaths = [
             "/purchase", // Not intended for direct access, only redirect from tito


### PR DESCRIPTION
Add a webhook route to listen to Tito ticket events.  
When a ticket registration is received, send a notification to Slack.  